### PR TITLE
fixes: 'will be initialized after' error

### DIFF
--- a/src/device-types/BaseDeviceType.h
+++ b/src/device-types/BaseDeviceType.h
@@ -22,6 +22,10 @@ public:
 
     virtual void setAvailability(bool online);
 
+private: 
+    HAMqtt& _mqtt;
+    friend class HAMqtt;
+
 protected:
     inline HAMqtt* mqtt() const
         { return &_mqtt; }
@@ -54,10 +58,7 @@ private:
         AvailabilityOffline
     };
 
-    HAMqtt& _mqtt;
     Availability _availability;
-
-    friend class HAMqtt;
 };
 
 #endif


### PR DESCRIPTION
Just got following error when including your lib in a platformio project:
BaseDeviceType.h:59:13: error: 'BaseDeviceType::_mqtt' will be initialized after [-Werror=reorder]
BaseDeviceType.h:42:23: error:   'const char* const BaseDeviceType::_componentName' [-Werror=reorder]
BaseDeviceType.cpp:5:1: error:   when initialized here [-Werror=reorder]