### PR TITLE
feat: add state_class to sensor

### DIFF
--- a/src/device-types/HASensor.cpp
+++ b/src/device-types/HASensor.cpp
@@ -152,6 +152,12 @@ uint16_t HASensor::calculateSerializedLength(
         size += strlen(_class) + 13; // 13 - length of the JSON decorators for this field
     }
 
+    // state class
+    if (_stateClass != nullptr) {
+        // Field format: ,"stat_cla":"[CLASS]"
+        size += strlen(_stateClass) + 14; // 14 - length of the JSON decorators for this field
+    }
+
     // units of measurement
     if (_units != nullptr) {
         // Format: ,"unit_of_meas":"[UNITS]"
@@ -189,6 +195,12 @@ bool HASensor::writeSerializedData(const char* serializedDevice) const
     if (_class != nullptr) {
         static const char Prefix[] PROGMEM = {",\"dev_cla\":\""};
         DeviceTypeSerializer::mqttWriteConstCharField(Prefix, _class);
+    }
+
+    // state class
+    if (_stateClass != nullptr) {
+        static const char Prefix[] PROGMEM = {",\"stat_cla\":\""};
+        DeviceTypeSerializer::mqttWriteConstCharField(Prefix, _stateClass);
     }
 
     // units of measurement

--- a/src/device-types/HASensor.h
+++ b/src/device-types/HASensor.h
@@ -61,6 +61,18 @@ public:
         { _class = className; }
 
     /**
+     * The state class of the sensor (measurement, total, total_increasing).
+     * Home Assistant has support for storing sensors as long-term statistics if the entity
+     * has the right properties. To opt-in for statistics, the sensor must have state_class
+     * set to one of the valid state classes: measurement, total or total_increasing.
+     * Long-term statistics is needed for sensors used on the energy dashboard.
+     *
+     * @param stateClass https://www.home-assistant.io/integrations/sensor.mqtt#state_class
+     */
+    inline void setStateClass(const char* stateClass)
+        { _stateClass = stateClass; }
+
+    /**
      * Defines the units of measurement of the sensor, if any.
      *
      * @param units For example: °C, %
@@ -82,6 +94,7 @@ private:
     bool writeSerializedData(const char* serializedDevice) const override;
 
     const char* _class;
+    const char* _stateClass;
     const char* _units;
     const char* _icon;
 };


### PR DESCRIPTION
state_class was missing and is needed for energy sensors for the new Energy dashboard. Now that I'm creating this PR, I see that there is already a PR from glamourfan with almost identical changes. Please approve this PR or PR from glamourfan so others do not have to invent the wheel, again.
Be assured that I tested these changes. I'm currently running this to sent my P1 smart meter data to home assistant.