### PR TITLE
Add support for state_class property to sensors

### DIFF
--- a/src/device-types/HASensor.cpp
+++ b/src/device-types/HASensor.cpp
@@ -11,6 +11,7 @@
 HASensor::HASensor(const char* uniqueId) :
     BaseDeviceType("sensor", uniqueId),
     _class(nullptr),
+    _stateClass(nullptr),
     _units(nullptr),
     _icon(nullptr)
 {
@@ -152,6 +153,12 @@ uint16_t HASensor::calculateSerializedLength(
         size += strlen(_class) + 13; // 13 - length of the JSON decorators for this field
     }
 
+    // state class
+    if (_stateClass != nullptr) {
+        // Field format: ,"state_class":"[STATE]"
+        size += strlen(_class) + 17; // 17 - length of the JSON decorators for this field
+    }
+
     // units of measurement
     if (_units != nullptr) {
         // Format: ,"unit_of_meas":"[UNITS]"
@@ -189,6 +196,12 @@ bool HASensor::writeSerializedData(const char* serializedDevice) const
     if (_class != nullptr) {
         static const char Prefix[] PROGMEM = {",\"dev_cla\":\""};
         DeviceTypeSerializer::mqttWriteConstCharField(Prefix, _class);
+    }
+
+    // state class
+    if (_stateClass != nullptr) {
+        static const char Prefix[] PROGMEM = {",\"state_class\":\""};
+        DeviceTypeSerializer::mqttWriteConstCharField(Prefix, _stateClass);
     }
 
     // units of measurement

--- a/src/device-types/HASensor.h
+++ b/src/device-types/HASensor.h
@@ -61,6 +61,14 @@ public:
         { _class = className; }
 
     /**
+     * Type of state represented by sensor, e.g. "measurement".
+     * 
+     * @param stateClassName https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes
+     */
+    inline void setStateClass(const char* stateClassName)
+        { _stateClass = stateClassName; }
+
+    /**
      * Defines the units of measurement of the sensor, if any.
      *
      * @param units For example: °C, %
@@ -82,6 +90,7 @@ private:
     bool writeSerializedData(const char* serializedDevice) const override;
 
     const char* _class;
+    const char* _stateClass;
     const char* _units;
     const char* _icon;
 };


### PR DESCRIPTION
Per https://www.home-assistant.io/more-info/statistics/ this enables them for use with the Statistics Graph card.