### PR TITLE
Doc: add comment regarding position feature usage

### DIFF
--- a/examples/cover/cover.ino
+++ b/examples/cover/cover.ino
@@ -12,8 +12,8 @@ HAMqtt mqtt(client, device);
 // "myCover" is unique ID of the cover. You should define your own ID.
 HACover cover("myCover", HACover::PositionFeature);
 
-// Cover with the position feature:
-// HACover cover("myCover", HACover::PositionFeature);
+// PositionFeature is optional, however required to be in a "stopped" state other than open or closed.
+// If ommitted, a CommandStop will result in HA treating the cover as either Open or Closed immediately after the command.
 
 void onCoverCommand(HACover::CoverCommand cmd, HACover* sender) {
     if (cmd == HACover::CommandOpen) {

--- a/examples/cover/cover.ino
+++ b/examples/cover/cover.ino
@@ -14,6 +14,7 @@ HACover cover("myCover", HACover::PositionFeature);
 
 // PositionFeature is optional, however required to be in a "stopped" state other than open or closed.
 // If ommitted, a CommandStop will result in HA treating the cover as either Open or Closed immediately after the command.
+// See https://www.home-assistant.io/integrations/cover.mqtt/
 
 void onCoverCommand(HACover::CoverCommand cmd, HACover* sender) {
     if (cmd == HACover::CommandOpen) {


### PR DESCRIPTION
The issue was that when sending a "stop" command HA would disable the "open" button (because it treated the cover as "open" immediately after a stop command). Essentially, interrupting an "open" with a stop command meant that it could not be set back to "opening" via the HA UI without first going through "closing" or "closed"

> a state_stopped state can be configured to indicate that the device is not moving. When this payload is received on the state_topic, and a position_topic is not configured, the cover will be set to state closed if its state was closing and to state open otherwise.

Setting a position (in my case 50 when opening or closing, and 0/100 respectively when open or closed) means that a stop during open or close leaves both buttons enabled in the HA UI.

This one stumped me for a while, eventually found the answer in the [HA MQTT Cover docs](https://www.home-assistant.io/integrations/cover.mqtt/), so just making a note for others.

PS - Thanks for the fantastic library, it was very easy to set up a pretty sophisticated UX with this + WiFiManager.

