### PR TITLE
Ability to get state code of mqtt connection

### DIFF
--- a/src/HAMqtt.cpp
+++ b/src/HAMqtt.cpp
@@ -183,6 +183,11 @@ bool HAMqtt::isConnected() const
     return _mqtt->connected();
 }
 
+int HAMqtt::getState() const
+{
+    return _mqtt->state();
+}
+
 void HAMqtt::addDeviceType(HABaseDeviceType* deviceType)
 {
     if (_devicesTypesNb + 1 >= _maxDevicesTypesNb) {

--- a/src/HAMqtt.h
+++ b/src/HAMqtt.h
@@ -203,6 +203,22 @@ public:
      */
     bool isConnected() const;
 
+     /**
+     * Returns the state code of mqtt connection.
+     * 
+     * MQTT_CONNECTION_TIMEOUT     -4
+     * MQTT_CONNECTION_LOST        -3
+     * MQTT_CONNECT_FAILED         -2
+     * MQTT_DISCONNECTED           -1
+     * MQTT_CONNECTED               0
+     * MQTT_CONNECT_BAD_PROTOCOL    1
+     * MQTT_CONNECT_BAD_CLIENT_ID   2
+     * MQTT_CONNECT_UNAVAILABLE     3
+     * MQTT_CONNECT_BAD_CREDENTIALS 4
+     * MQTT_CONNECT_UNAUTHORIZED    5
+     */
+    int getState() const;
+
     /**
      * Adds a new device's type to the MQTT.
      * Each time the connection with MQTT broker is acquired, the HAMqtt class


### PR DESCRIPTION
_getState()_ exposes the state code of the mqtt connection directly from _PubSubClient_ library.

_isConnected()_ method is used to detect if the client is connected (or not) to the mqtt broken, but, it's not possible to identify the reason behind a connection error.
This method is helpful to detect the exact reason of this kind of error.

Here an example on how it could be used:
```c
if(!mqtt.isConnected()){
  switch(mqtt.getState()){
    case -4:
       Serial.println("Connection timeout");
       break;
    case -3:
       Serial.println("Connection lost");
       break;
    case -2:
       Serial.println("Connection failed");
       break;
    case -1:
       Serial.println("Disconnected");
       break;
    case 1:
       Serial.println("Bad protocol");
       break;
    case 2:
       Serial.println("Bad client id");
       break;
    case 3:
       Serial.println("Unavailable");
       break;
    case 4:
       Serial.println("Bad credentials");
       break;
    case 5:
       Serial.println("Unauthorized");
       break;
  }
}
```