### PR TITLE
Adding support for 'state_class'

### DIFF
--- a/src/device-types/HASensor.cpp
+++ b/src/device-types/HASensor.cpp
@@ -7,6 +7,7 @@
 HASensor::HASensor(const char* uniqueId) :
     HABaseDeviceType(AHATOFSTR(HAComponentSensor), uniqueId),
     _deviceClass(nullptr),
+    _stateClass(nullptr),
     _forceUpdate(false),
     _icon(nullptr),
     _unitOfMeasurement(nullptr)
@@ -29,6 +30,7 @@ void HASensor::buildSerializer()
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _deviceClass);
+    _serializer->set(AHATOFSTR(HAStateClassProperty), _stateClass);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
     _serializer->set(AHATOFSTR(HAUnitOfMeasurementProperty), _unitOfMeasurement);
 

--- a/src/device-types/HASensor.h
+++ b/src/device-types/HASensor.h
@@ -42,6 +42,15 @@ public:
         { _deviceClass = deviceClass; }
 
     /**
+     * Sets state of the device.
+     * You can find list of available values here: https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes
+     *
+     * @param stateClass The class name.
+     */
+    inline void setStateClass(const char* stateClass)
+        { _stateClass = stateClass; }
+
+    /**
      * Forces HA panel to process each incoming value (MQTT message).
      * It's useful if you want to have meaningful value graphs in history.
      *
@@ -74,6 +83,9 @@ protected:
 private:
     /// The device class. It can be nullptr.
     const char* _deviceClass;
+
+    /// The state class. It can be nullptr.
+    const char* _stateClass;
 
     /// The force update flag for the HA panel.
     bool _forceUpdate;

--- a/src/utils/HADictionary.cpp
+++ b/src/utils/HADictionary.cpp
@@ -40,6 +40,7 @@ const char HANameProperty[] PROGMEM = {"name"};
 const char HAUniqueIdProperty[] PROGMEM = {"uniq_id"};
 const char HADeviceProperty[] PROGMEM = {"dev"};
 const char HADeviceClassProperty[] PROGMEM = {"dev_cla"};
+const char HAStateClassProperty[] PROGMEM = {"stat_cla"};
 const char HAIconProperty[] PROGMEM = {"ic"};
 const char HARetainProperty[] PROGMEM = {"ret"};
 const char HASourceTypeProperty[] PROGMEM = {"src_type"};

--- a/src/utils/HADictionary.h
+++ b/src/utils/HADictionary.h
@@ -40,6 +40,7 @@ extern const char HANameProperty[];
 extern const char HAUniqueIdProperty[];
 extern const char HADeviceProperty[];
 extern const char HADeviceClassProperty[];
+extern const char HAStateClassProperty[];
 extern const char HAIconProperty[];
 extern const char HARetainProperty[];
 extern const char HASourceTypeProperty[];


### PR DESCRIPTION
Adding the ability to provide `state_class` for sensors via setting `setStateClass` property for `HASensor` / `HASensorNumber` to fix missing setup of [https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes).

Here's an example to use the new property:
```c++
// ...
HASensorNumber mySensor("mySensor");
// ...
void setup() {
    // ...
    // configure sensor
    mySensor.setName("mySensor");
    mySensor.setIcon("mdi:thermometer");
    mySensor.setUnitOfMeasurement("°C");
    mySensor.setDeviceClass("temperature");
    mySensor.setStateClass("measurement");
    // ...
}

```