### PR TITLE
Set device obj_id to unique_id

### DIFF
--- a/src/HADevice.cpp
+++ b/src/HADevice.cpp
@@ -55,6 +55,7 @@ bool HADevice::setUniqueId(const byte* uniqueId, const uint16_t length)
     _uniqueId = HAUtils::byteArrayToStr(uniqueId, length);
     _ownsUniqueId = true;
     _serializer->set(AHATOFSTR(HADeviceIdentifiersProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HADeviceIdentifiersProperty), _uniqueId);
     return true;
 }
 

--- a/src/HADevice.cpp
+++ b/src/HADevice.cpp
@@ -55,7 +55,6 @@ bool HADevice::setUniqueId(const byte* uniqueId, const uint16_t length)
     _uniqueId = HAUtils::byteArrayToStr(uniqueId, length);
     _ownsUniqueId = true;
     _serializer->set(AHATOFSTR(HADeviceIdentifiersProperty), _uniqueId);
-    _serializer->set(AHATOFSTR(HADeviceIdentifiersProperty), _uniqueId);
     return true;
 }
 

--- a/src/device-types/HABinarySensor.cpp
+++ b/src/device-types/HABinarySensor.cpp
@@ -33,9 +33,10 @@ void HABinarySensor::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 7); // 7 - max properties nb
+    _serializer = new HASerializer(this, 8); // 8 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
     _serializer->set(HASerializer::WithDevice);

--- a/src/device-types/HAButton.cpp
+++ b/src/device-types/HAButton.cpp
@@ -20,9 +20,10 @@ void HAButton::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 8); // 8 - max properties nb
+    _serializer = new HASerializer(this, 9); // 9 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
 

--- a/src/device-types/HACamera.cpp
+++ b/src/device-types/HACamera.cpp
@@ -27,9 +27,10 @@ void HACamera::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 7); // 7 - max properties nb
+    _serializer = new HASerializer(this, 8); // 8 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
     _serializer->set(
         AHATOFSTR(HAEncodingProperty),

--- a/src/device-types/HACover.cpp
+++ b/src/device-types/HACover.cpp
@@ -54,7 +54,7 @@ void HACover::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 11); // 11 - max properties nb
+    _serializer = new HASerializer(this, 12); // 12 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);

--- a/src/device-types/HADeviceTracker.cpp
+++ b/src/device-types/HADeviceTracker.cpp
@@ -33,9 +33,10 @@ void HADeviceTracker::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 7); // 7 - max properties nb
+    _serializer = new HASerializer(this, 8); // 8 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
     _serializer->set(
         AHATOFSTR(HASourceTypeProperty),

--- a/src/device-types/HAFan.cpp
+++ b/src/device-types/HAFan.cpp
@@ -55,9 +55,10 @@ void HAFan::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 13); // 13 - max properties nb
+    _serializer = new HASerializer(this, 14); // 14 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
 
     if (_retain) {

--- a/src/device-types/HAHVAC.cpp
+++ b/src/device-types/HAHVAC.cpp
@@ -183,9 +183,10 @@ void HAHVAC::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 27); // 27 - max properties nb
+    _serializer = new HASerializer(this, 28); // 28 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
 
     if (_retain) {

--- a/src/device-types/HALight.cpp
+++ b/src/device-types/HALight.cpp
@@ -128,9 +128,10 @@ void HALight::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 18); // 18 - max properties nb
+    _serializer = new HASerializer(this, 19); // 19 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
 
     if (_retain) {

--- a/src/device-types/HALock.cpp
+++ b/src/device-types/HALock.cpp
@@ -35,9 +35,10 @@ void HALock::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 9); // 9 - max properties nb
+    _serializer = new HASerializer(this, 10); // 10 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
 
     if (_retain) {

--- a/src/device-types/HANumber.cpp
+++ b/src/device-types/HANumber.cpp
@@ -42,10 +42,11 @@ void HANumber::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 15); // 15 - max properties nb
+    _serializer = new HASerializer(this, 16); // 16 - max properties nb
 
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
     _serializer->set(AHATOFSTR(HAUnitOfMeasurementProperty), _unitOfMeasurement);

--- a/src/device-types/HAScene.cpp
+++ b/src/device-types/HAScene.cpp
@@ -19,9 +19,10 @@ void HAScene::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 7); // 7 - max properties nb
+    _serializer = new HASerializer(this, 8); // 8 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
 
     // optional property

--- a/src/device-types/HASelect.cpp
+++ b/src/device-types/HASelect.cpp
@@ -91,9 +91,10 @@ void HASelect::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 10); // 10 - max properties nb
+    _serializer = new HASerializer(this, 11); // 11 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
     _serializer->set(
         AHATOFSTR(HAOptionsProperty),

--- a/src/device-types/HASensor.cpp
+++ b/src/device-types/HASensor.cpp
@@ -25,9 +25,10 @@ void HASensor::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 9); // 9 - max properties nb
+    _serializer = new HASerializer(this, 10); // 10 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _deviceClass);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
     _serializer->set(AHATOFSTR(HAUnitOfMeasurementProperty), _unitOfMeasurement);

--- a/src/device-types/HASwitch.cpp
+++ b/src/device-types/HASwitch.cpp
@@ -36,9 +36,10 @@ void HASwitch::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 10); // 10 - max properties nb
+    _serializer = new HASerializer(this, 11); // 11 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
 

--- a/src/utils/HADictionary.cpp
+++ b/src/utils/HADictionary.cpp
@@ -38,6 +38,7 @@ const char HADeviceModelProperty[] PROGMEM = {"mdl"};
 const char HADeviceSoftwareVersionProperty[] PROGMEM = {"sw"};
 const char HANameProperty[] PROGMEM = {"name"};
 const char HAUniqueIdProperty[] PROGMEM = {"uniq_id"};
+const char HAObjectIdProperty[] PROGMEM = {"obj_id"};
 const char HADeviceProperty[] PROGMEM = {"dev"};
 const char HADeviceClassProperty[] PROGMEM = {"dev_cla"};
 const char HAIconProperty[] PROGMEM = {"ic"};

--- a/src/utils/HADictionary.h
+++ b/src/utils/HADictionary.h
@@ -38,6 +38,7 @@ extern const char HADeviceModelProperty[];
 extern const char HADeviceSoftwareVersionProperty[];
 extern const char HANameProperty[];
 extern const char HAUniqueIdProperty[];
+extern const char HAObjectIdProperty[];
 extern const char HADeviceProperty[];
 extern const char HADeviceClassProperty[];
 extern const char HAIconProperty[];


### PR DESCRIPTION
This pull request adds *obj_id* on each component/entity configuration. This value is used by home assistant as *entity_id* (instead of generating one from the name).

**Problem solved by this pull request:**  
We create one sensor with a given name ("Room1 light"), doing so, Home assistant  creates an entity, its entity_id is generated from the name ("light.room1_light").
After a while we decide to improve our sketch and we'd like to change its name to keep it consistent ("Room1 light1"), Home assistant will create a new entity with the id ("light.room1_light1").

Specifying the *obj_id*, will solve this problem.



