### PR TITLE
Add support for attributes

### DIFF
--- a/src/device-types/HASensor.cpp
+++ b/src/device-types/HASensor.cpp
@@ -9,6 +9,7 @@ HASensor::HASensor(const char* uniqueId) :
     _deviceClass(nullptr),
     _stateClass(nullptr),
     _forceUpdate(false),
+    _hasAttributes(false),
     _icon(nullptr),
     _unitOfMeasurement(nullptr)
 {
@@ -20,13 +21,20 @@ bool HASensor::setValue(const char* value)
     return publishOnDataTopic(AHATOFSTR(HAStateTopic), value, true);
 }
 
+bool HASensor::setAttributes(const char* json)
+{
+    if (!_hasAttributes)
+        return false;
+    return publishOnDataTopic(AHATOFSTR(HAAttributeTopic), json, true);
+}
+
 void HASensor::buildSerializer()
 {
     if (_serializer || !uniqueId()) {
         return;
     }
 
-    _serializer = new HASerializer(this, 9); // 9 - max properties nb
+    _serializer = new HASerializer(this, 11); // 11 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _deviceClass);
@@ -42,10 +50,11 @@ void HASensor::buildSerializer()
             HASerializer::BoolPropertyType
         );
     }
-
     _serializer->set(HASerializer::WithDevice);
     _serializer->set(HASerializer::WithAvailability);
     _serializer->topic(AHATOFSTR(HAStateTopic));
+    if (_hasAttributes)
+        _serializer->topic(AHATOFSTR(HAAttributeTopic));
 }
 
 void HASensor::onMqttConnected()

--- a/src/device-types/HASensor.cpp
+++ b/src/device-types/HASensor.cpp
@@ -7,6 +7,7 @@
 HASensor::HASensor(const char* uniqueId) :
     HABaseDeviceType(AHATOFSTR(HAComponentSensor), uniqueId),
     _deviceClass(nullptr),
+    _stateClass(nullptr),
     _forceUpdate(false),
     _icon(nullptr),
     _unitOfMeasurement(nullptr)
@@ -29,6 +30,7 @@ void HASensor::buildSerializer()
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAUniqueIdProperty), _uniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _deviceClass);
+    _serializer->set(AHATOFSTR(HAStateClassProperty), _stateClass);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
     _serializer->set(AHATOFSTR(HAUnitOfMeasurementProperty), _unitOfMeasurement);
 

--- a/src/device-types/HASensor.h
+++ b/src/device-types/HASensor.h
@@ -42,6 +42,15 @@ public:
         { _deviceClass = deviceClass; }
 
     /**
+     * Sets state of the device.
+     * You can find list of available values here: https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes
+     *
+     * @param stateClass The class name.
+     */
+    inline void setStateClass(const char* stateClass)
+        { _stateClass = stateClass; }
+
+    /**
      * Forces HA panel to process each incoming value (MQTT message).
      * It's useful if you want to have meaningful value graphs in history.
      *
@@ -74,6 +83,9 @@ protected:
 private:
     /// The device class. It can be nullptr.
     const char* _deviceClass;
+
+    /// The state class. It can be nullptr.
+    const char* _stateClass;
 
     /// The force update flag for the HA panel.
     bool _forceUpdate;

--- a/src/device-types/HASensor.h
+++ b/src/device-types/HASensor.h
@@ -33,6 +33,14 @@ public:
     bool setValue(const char* value);
 
     /**
+     * Publishes the MQTT message with the given attributes.
+     *
+     * @param attributes A JSON String representation of the sensor's attributes
+     * @returns Returns `true` if MQTT message has been published successfully.
+     */
+    bool setAttributes(const char* attributes);
+
+    /**
      * Sets class of the device.
      * You can find list of available values here: https://www.home-assistant.io/integrations/sensor/#device-class
      *
@@ -58,6 +66,13 @@ public:
      */
     inline void setForceUpdate(bool forceUpdate)
         { _forceUpdate = forceUpdate; }
+
+    /**
+     * Adds the attributes topic to the config phase
+     * THe flag can only be set, disabling the flag afterwards has no use
+     */
+    inline void hasAttributes()
+        { _hasAttributes = true; }
 
     /**
      * Sets icon of the sensor.
@@ -89,6 +104,9 @@ private:
 
     /// The force update flag for the HA panel.
     bool _forceUpdate;
+
+    /// The attributes flag indicating attributes will be set
+    bool _hasAttributes;
 
     /// The icon of the sensor. It can be nullptr.
     const char* _icon;

--- a/src/utils/HADictionary.cpp
+++ b/src/utils/HADictionary.cpp
@@ -40,6 +40,7 @@ const char HANameProperty[] PROGMEM = {"name"};
 const char HAUniqueIdProperty[] PROGMEM = {"uniq_id"};
 const char HADeviceProperty[] PROGMEM = {"dev"};
 const char HADeviceClassProperty[] PROGMEM = {"dev_cla"};
+const char HAStateClassProperty[] PROGMEM = {"stat_cla"};
 const char HAIconProperty[] PROGMEM = {"ic"};
 const char HARetainProperty[] PROGMEM = {"ret"};
 const char HASourceTypeProperty[] PROGMEM = {"src_type"};

--- a/src/utils/HADictionary.cpp
+++ b/src/utils/HADictionary.cpp
@@ -78,6 +78,7 @@ const char HAConfigTopic[] PROGMEM = {"config"};
 const char HAAvailabilityTopic[] PROGMEM = {"avty_t"};
 const char HATopic[] PROGMEM = {"t"};
 const char HAStateTopic[] PROGMEM = {"stat_t"};
+const char HAAttributeTopic[] PROGMEM = {"json_attr_t"};
 const char HACommandTopic[] PROGMEM = {"cmd_t"};
 const char HAPositionTopic[] PROGMEM = {"pos_t"};
 const char HAPercentageStateTopic[] PROGMEM = {"pct_stat_t"};

--- a/src/utils/HADictionary.h
+++ b/src/utils/HADictionary.h
@@ -40,6 +40,7 @@ extern const char HANameProperty[];
 extern const char HAUniqueIdProperty[];
 extern const char HADeviceProperty[];
 extern const char HADeviceClassProperty[];
+extern const char HAStateClassProperty[];
 extern const char HAIconProperty[];
 extern const char HARetainProperty[];
 extern const char HASourceTypeProperty[];

--- a/src/utils/HADictionary.h
+++ b/src/utils/HADictionary.h
@@ -78,6 +78,7 @@ extern const char HAConfigTopic[];
 extern const char HAAvailabilityTopic[];
 extern const char HATopic[];
 extern const char HAStateTopic[];
+extern const char HAAttributeTopic[];
 extern const char HACommandTopic[];
 extern const char HAPositionTopic[];
 extern const char HAPercentageStateTopic[];

--- a/src/utils/HANumeric.h
+++ b/src/utils/HANumeric.h
@@ -229,7 +229,7 @@ private:
 
     explicit HANumeric(const int64_t value);
 
-    friend class HANumeric;
+//    friend class HANumeric;
 };
 
 #endif


### PR DESCRIPTION
As not all telemetry deserves its own dedicated sensor, some detailed telemetry data would be stored in attributes. Most common use case is to add debug info, or aother less important sensor data as json object to one of the sensors

The code is minimized to publishing a string, which in fact for proper HA support should be a json object. However I think creating the json object should not be part of this library