### PR TITLE
Slider support for cover

### DIFF
--- a/src/device-types/HACover.cpp
+++ b/src/device-types/HACover.cpp
@@ -203,7 +203,13 @@ void HACover::handleSetPosition(const uint8_t* cmd, const uint16_t length)
 
     if (memcmp_P(cmd, HAStateNone, length) == 0) {
         _setPosCallback(HANumeric(), this);
-    } 
+    } else {
+        HANumeric number = HANumeric::fromStr(cmd, length);
+        if (number.isSet()) {
+            number.setPrecision(0);
+            _setPosCallback(number, this);
+        }
+    }
 }
 
 #endif

--- a/src/device-types/HACover.h
+++ b/src/device-types/HACover.h
@@ -2,10 +2,12 @@
 #define AHA_HACOVER_H
 
 #include "HABaseDeviceType.h"
+#include "../utils/HANumeric.h"
 
 #ifndef EX_ARDUINOHA_COVER
 
 #define HACOVER_CALLBACK(name) void (*name)(CoverCommand cmd, HACover* sender)
+#define HACOVER_SET_POS_CALLBACK(name) void (*name)(HANumeric number, HACover* sender)
 
 /**
  * HACover allows to control a cover (such as blinds, a roller shutter or a garage door).
@@ -147,6 +149,15 @@ public:
     inline void onCommand(HACOVER_CALLBACK(callback))
         { _commandCallback = callback; }
 
+    /**
+     * Registers callback that will be called each time the set position command from HA is received.
+     * Please note that it's not possible to register multiple callbacks for the same cover.
+     *
+     * @param callback
+     */
+    inline void onSetPosition(HACOVER_SET_POS_CALLBACK(callback))
+        { _setPosCallback = callback; }
+
 protected:
     virtual void buildSerializer() override;
     virtual void onMqttConnected() override;
@@ -180,6 +191,14 @@ private:
      * @param length Length of the command.
      */
     void handleCommand(const uint8_t* cmd, const uint16_t length);
+    
+    /**
+     * Parses the given set position command and executes the cover's callback..
+     *
+     * @param cmd The data of the command.
+     * @param length Length of the command.
+     */
+    void handleSetPosition(const uint8_t *cmd, const uint16_t length);
 
     /// Features enabled for the cover.
     const uint8_t _features;
@@ -204,6 +223,10 @@ private:
 
     /// The command callback that will be called when clicking the cover's button in the HA panel.
     HACOVER_CALLBACK(_commandCallback);
+
+    /// The command callback that will be called when sliding the cover's slider in the HA panel.
+    HACOVER_SET_POS_CALLBACK(_setPosCallback);
+
 };
 
 #endif

--- a/src/utils/HADictionary.cpp
+++ b/src/utils/HADictionary.cpp
@@ -79,6 +79,7 @@ const char HATopic[] PROGMEM = {"t"};
 const char HAStateTopic[] PROGMEM = {"stat_t"};
 const char HACommandTopic[] PROGMEM = {"cmd_t"};
 const char HAPositionTopic[] PROGMEM = {"pos_t"};
+const char HASetPositionTopic[] PROGMEM = {"set_pos_t"};
 const char HAPercentageStateTopic[] PROGMEM = {"pct_stat_t"};
 const char HAPercentageCommandTopic[] PROGMEM = {"pct_cmd_t"};
 const char HABrightnessCommandTopic[] PROGMEM = {"bri_cmd_t"};

--- a/src/utils/HADictionary.h
+++ b/src/utils/HADictionary.h
@@ -79,6 +79,7 @@ extern const char HATopic[];
 extern const char HAStateTopic[];
 extern const char HACommandTopic[];
 extern const char HAPositionTopic[];
+extern const char HASetPositionTopic[];
 extern const char HAPercentageStateTopic[];
 extern const char HAPercentageCommandTopic[];
 extern const char HABrightnessCommandTopic[];


### PR DESCRIPTION
Simply making you aware of the extension i made, may be they can be of use. If not ignore my pr.
Nice and clear code btw :)

I needed a slider support. (as some others also requested i think)
I included a command topic "set_position_topic" as documented here https://www.home-assistant.io/integrations/cover.mqtt/
the topic is only "activated" for HACover::PositionFeature
I introduced a new callback to get the slider values back. 
Borrowed from your HANumber implementation. You might want to check that part. 

I have not checked if this value also needs to be/ can feed back to HA, yet (Like you do with the number slider, because i think cover gets that information from the "position_topic") I'm just happy that it works! 
I have not written any test cases to verify my code, yet. May be i do. 
