### PR TITLE
Concatenate MQTT device id with each sub-device id

### DIFF
--- a/src/HADevice.cpp
+++ b/src/HADevice.cpp
@@ -18,7 +18,20 @@ HADevice::HADevice() :
 
 }
 
+HADevice::HADevice(const char* uniqueId) :
+    _uniqueId(uniqueId),
+    HADEVICE_INIT
+{
+    _serializer->set(AHATOFSTR(HADeviceIdentifiersProperty), _uniqueId);
+}
 
+HADevice::HADevice(const byte* uniqueId, const uint16_t length) :
+    _uniqueId(HAUtils::byteArrayToStr(uniqueId, length)),
+    HADEVICE_INIT
+{
+    _ownsUniqueId = true;
+    _serializer->set(AHATOFSTR(HADeviceIdentifiersProperty), _uniqueId);
+}
 
 HADevice::~HADevice()
 {
@@ -33,41 +46,15 @@ HADevice::~HADevice()
     }
 }
 
-void HADevice::serializeID(const std::string &uniqueId)
+bool HADevice::setUniqueId(const byte* uniqueId, const uint16_t length)
 {
-    HADevice const *device = HAMqtt::instance()->getDevice();
-    if (device == nullptr)
-    {
-        return;
-    }
-
-    _serializedID = std::string(device->getUniqueId()) + "_" + uniqueId;
-    _serializer->set(AHATOFSTR(HADeviceIdentifiersProperty), _serializedID.c_str());
-}
-
-HADevice::HADevice(const char *uniqueId) : _uniqueId(uniqueId),
-                                           HADEVICE_INIT
-{
-    serializeID(uniqueId);
-}
-
-HADevice::HADevice(const byte *uniqueId, const uint16_t length) : _uniqueId(HAUtils::byteArrayToStr(uniqueId, length)),
-                                                                  HADEVICE_INIT
-{
-    _ownsUniqueId = true;
-    serializeID(_uniqueId);
-}
-
-bool HADevice::setUniqueId(const byte *uniqueId, const uint16_t length)
-{
-    if (_uniqueId != nullptr)
-    {
+    if (_uniqueId) {
         return false; // unique ID cannot be changed at runtime once it's set
     }
 
     _uniqueId = HAUtils::byteArrayToStr(uniqueId, length);
     _ownsUniqueId = true;
-    serializeID(_uniqueId);
+    _serializer->set(AHATOFSTR(HADeviceIdentifiersProperty), _uniqueId);
     return true;
 }
 

--- a/src/device-types/HABaseDeviceType.cpp
+++ b/src/device-types/HABaseDeviceType.cpp
@@ -5,16 +5,37 @@
 #include "../utils/HASerializer.h"
 
 HABaseDeviceType::HABaseDeviceType(
-    const __FlashStringHelper* componentName,
-    const char* uniqueId
-) :
-    _componentName(componentName),
-    _uniqueId(uniqueId),
-    _name(nullptr),
-    _serializer(nullptr),
-    _availability(AvailabilityDefault)
+    const __FlashStringHelper *componentName,
+    const char *uniqueIdSuffix) : _componentName(componentName),
+                                  _uniqueId(nullptr), // initialize to nullptr
+                                  _name(nullptr),
+                                  _serializer(nullptr),
+                                  _availability(AvailabilityDefault)
 {
-    if (mqtt()) {
+    HADevice const *device = HAMqtt::instance()->getDevice();
+    if (device)
+    {
+        const char *mainUniqueId = device->getUniqueId();
+        if (mainUniqueId && uniqueIdSuffix)
+        {
+            size_t totalLength = strlen(mainUniqueId) + strlen(uniqueIdSuffix) + 2;
+            char *concatenatedId = new char[totalLength];
+            snprintf(concatenatedId, totalLength, "%s_%s", mainUniqueId, uniqueIdSuffix);
+            Serial.println(concatenatedId); // Print for debugging
+            _uniqueId = concatenatedId;
+        }
+        else
+        {
+            _uniqueId = uniqueIdSuffix; // Or another sensible default
+        }
+    }
+    else
+    {
+        _uniqueId = uniqueIdSuffix;
+    }
+
+    if (mqtt())
+    {
         mqtt()->addDeviceType(this);
     }
 }
@@ -25,30 +46,29 @@ void HABaseDeviceType::setAvailability(bool online)
     publishAvailability();
 }
 
-HAMqtt* HABaseDeviceType::mqtt()
+HAMqtt *HABaseDeviceType::mqtt()
 {
     return HAMqtt::instance();
 }
 
 void HABaseDeviceType::subscribeTopic(
-    const char* uniqueId,
-    const __FlashStringHelper* topic
-)
+    const char *uniqueId,
+    const __FlashStringHelper *topic)
 {
     const uint16_t topicLength = HASerializer::calculateDataTopicLength(
         uniqueId,
-        topic
-    );
-    if (topicLength == 0) {
+        topic);
+    if (topicLength == 0)
+    {
         return;
     }
 
     char fullTopic[topicLength];
     if (!HASerializer::generateDataTopic(
-        fullTopic,
-        uniqueId,
-        topic
-    )) {
+            fullTopic,
+            uniqueId,
+            topic))
+    {
         return;
     }
 
@@ -56,10 +76,9 @@ void HABaseDeviceType::subscribeTopic(
 }
 
 void HABaseDeviceType::onMqttMessage(
-    const char* topic,
-    const uint8_t* payload,
-    const uint16_t length
-)
+    const char *topic,
+    const uint8_t *payload,
+    const uint16_t length)
 {
     (void)topic;
     (void)payload;
@@ -68,7 +87,8 @@ void HABaseDeviceType::onMqttMessage(
 
 void HABaseDeviceType::destroySerializer()
 {
-    if (_serializer) {
+    if (_serializer)
+    {
         delete _serializer;
         _serializer = nullptr;
     }
@@ -78,25 +98,26 @@ void HABaseDeviceType::publishConfig()
 {
     buildSerializer();
 
-    if (_serializer == nullptr) {
+    if (_serializer == nullptr)
+    {
         return;
     }
 
     const uint16_t topicLength = HASerializer::calculateConfigTopicLength(
         componentName(),
-        uniqueId()
-    );
+        uniqueId());
     const uint16_t dataLength = _serializer->calculateSize();
 
-    if (topicLength > 0 && dataLength > 0) {
+    if (topicLength > 0 && dataLength > 0)
+    {
         char topic[topicLength];
         HASerializer::generateConfigTopic(
             topic,
             componentName(),
-            uniqueId()
-        );
+            uniqueId());
 
-        if (mqtt()->beginPublish(topic, dataLength, true)) {
+        if (mqtt()->beginPublish(topic, dataLength, true))
+        {
             _serializer->flush();
             mqtt()->endPublish();
         }
@@ -107,12 +128,12 @@ void HABaseDeviceType::publishConfig()
 
 void HABaseDeviceType::publishAvailability()
 {
-    const HADevice* device = mqtt()->getDevice();
+    const HADevice *device = mqtt()->getDevice();
     if (
         !device ||
         device->isSharedAvailabilityEnabled() ||
-        !isAvailabilityConfigured()
-    ) {
+        !isAvailabilityConfigured())
+    {
         return;
     }
 
@@ -121,80 +142,81 @@ void HABaseDeviceType::publishAvailability()
         _availability == AvailabilityOnline
             ? AHATOFSTR(HAOnline)
             : AHATOFSTR(HAOffline),
-        true
-    );
+        true);
 }
 
 bool HABaseDeviceType::publishOnDataTopic(
-    const __FlashStringHelper* topic,
-    const __FlashStringHelper* payload,
-    bool retained
-)
+    const __FlashStringHelper *topic,
+    const __FlashStringHelper *payload,
+    bool retained)
 {
-    if (!payload) {
+    if (!payload)
+    {
         return false;
     }
 
     return publishOnDataTopic(
         topic,
-        reinterpret_cast<const uint8_t*>(payload),
+        reinterpret_cast<const uint8_t *>(payload),
         strlen_P(AHAFROMFSTR(payload)),
         retained,
-        true
-    );
+        true);
 }
 
 bool HABaseDeviceType::publishOnDataTopic(
-    const __FlashStringHelper* topic,
-    const char* payload,
-    bool retained
-)
+    const __FlashStringHelper *topic,
+    const char *payload,
+    bool retained)
 {
-    if (!payload) {
+    if (!payload)
+    {
         return false;
     }
 
     return publishOnDataTopic(
         topic,
-        reinterpret_cast<const uint8_t*>(payload),
+        reinterpret_cast<const uint8_t *>(payload),
         strlen(payload),
-        retained
-    );
+        retained);
 }
 
 bool HABaseDeviceType::publishOnDataTopic(
-    const __FlashStringHelper* topic,
-    const uint8_t* payload,
+    const __FlashStringHelper *topic,
+    const uint8_t *payload,
     const uint16_t length,
     bool retained,
-    bool isProgmemData
-)
+    bool isProgmemData)
 {
-    if (!payload) {
+    if (!payload)
+    {
         return false;
     }
 
     const uint16_t topicLength = HASerializer::calculateDataTopicLength(
         uniqueId(),
-        topic
-    );
-    if (topicLength == 0) {
+        topic);
+    if (topicLength == 0)
+    {
         return false;
     }
 
     char fullTopic[topicLength];
     if (!HASerializer::generateDataTopic(
-        fullTopic,
-        uniqueId(),
-        topic
-    )) {
+            fullTopic,
+            uniqueId(),
+            topic))
+    {
         return false;
     }
 
-    if (mqtt()->beginPublish(fullTopic, length, retained)) {
-        if (isProgmemData) {
+    if (mqtt()->beginPublish(fullTopic, length, retained))
+    {
+        if (isProgmemData)
+        {
             mqtt()->writePayload(AHATOFSTR(payload));
-        } else {
+        }
+        else
+        {
             mqtt()->writePayload(payload, length);
         }
 


### PR DESCRIPTION
Thanks as always for this great library!

This PR transparently concatenates the MQTT device identifier into device IDs for each sub-device. This allows automatic device discovery and publishing for multiple devices running the same code.

The change is made in the `HABaseDeviceType` constructor:

```C++
HABaseDeviceType::HABaseDeviceType(
    const __FlashStringHelper *componentName,
    const char *uniqueIdSuffix) : _componentName(componentName),
                                  _uniqueId(nullptr), // initialize to nullptr
                                  _name(nullptr),
                                  _serializer(nullptr),
                                  _availability(AvailabilityDefault)
{
    HADevice const *device = HAMqtt::instance()->getDevice();
    if (device)
    {
        const char *mainUniqueId = device->getUniqueId();
        if (mainUniqueId && uniqueIdSuffix)
        {
            size_t totalLength = strlen(mainUniqueId) + strlen(uniqueIdSuffix) + 2;
            char *concatenatedId = new char[totalLength];
            snprintf(concatenatedId, totalLength, "%s_%s", mainUniqueId, uniqueIdSuffix);
            _uniqueId = concatenatedId;
        }
        else
        {
            _uniqueId = uniqueIdSuffix;
        }
    }
    else
    {
        _uniqueId = uniqueIdSuffix;
    }

    if (mqtt())
    {
        mqtt()->addDeviceType(this);
    }
}
``` 

C++ is not my everyday language, so please point out if I've done something boneheaded here.