### PR TITLE
Adding option to add entity category to certain sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.1
+**New features:**
+* Added support for assigning sensors to entity categories
+
 ## 2.1.0
 
 **New features:**

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
-name=home-assistant-integration
-version=2.1.0
+name=home-assistant-integration-extended
+version=2.1.1
 author=Dawid Chyrzynski <dev@chyrzynski.pl>
-maintainer=Dawid Chyrzynski <dev@chyrzynski.pl>
-sentence=Home Assistant MQTT integration for Arduino
-paragraph=Lightweight library that provides easy to use API for integrating your Arduino/ESP based device with Home Assistant.
+maintainer=Kyle Johnson
+sentence=Extended Home Assistant MQTT integration for Arduino
+paragraph=Lightweight library that provides easy to use API for integrating your Arduino/ESP based device with Home Assistant. Includes option to use entity_categories for sensors.
 category=Communication
-url=https://github.com/dawidchyrzynski/arduino-home-assistant
+url=https://github.com/pkscout/arduino-home-assistant
 architectures=*
 depends=PubSubClient

--- a/src/device-types/HABinarySensor.cpp
+++ b/src/device-types/HABinarySensor.cpp
@@ -8,7 +8,8 @@ HABinarySensor::HABinarySensor(const char* uniqueId) :
     HABaseDeviceType(AHATOFSTR(HAComponentBinarySensor), uniqueId),
     _class(nullptr),
     _icon(nullptr),
-    _currentState(false)
+    _currentState(false),
+    _entityCategory(nullptr)
 {
 
 }
@@ -42,11 +43,12 @@ void HABinarySensor::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 9); // 9 - max properties nb
+    _serializer = new HASerializer(this, 10); // 10 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAObjectIdProperty), _objectId);
     _serializer->set(HASerializer::WithUniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);
+    _serializer->set(AHATOFSTR(HAStateEntityCategory), _entityCategory);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
 
     if (_expireAfter.isSet()) {

--- a/src/device-types/HABinarySensor.h
+++ b/src/device-types/HABinarySensor.h
@@ -64,6 +64,15 @@ public:
         { _class = deviceClass; }
 
     /**
+     * Sets the entity category for the sensor.
+     * See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+     *
+     * @param entityCategory The category name.
+     */
+    inline void setEntityCategory(const char* entityCategory)
+        { _entityCategory = entityCategory; }
+
+    /**
      * Sets icon of the sensor.
      * Any icon from MaterialDesignIcons.com (for example: `mdi:home`).
      *
@@ -88,6 +97,9 @@ private:
     /// The device class. It can be nullptr.
     const char* _class;
 
+    /// The entity category for the sensor. It can be nullptr. See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+    const char* _entityCategory;
+    
     /// The icon of the sensor. It can be nullptr.
     const char* _icon;
 

--- a/src/device-types/HAButton.cpp
+++ b/src/device-types/HAButton.cpp
@@ -7,6 +7,7 @@
 HAButton::HAButton(const char* uniqueId) :
     HABaseDeviceType(AHATOFSTR(HAComponentButton), uniqueId),
     _class(nullptr),
+    _entityCategory(nullptr),
     _icon(nullptr),
     _retain(false),
     _commandCallback(nullptr)
@@ -20,11 +21,12 @@ void HAButton::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 9); // 9 - max properties nb
+    _serializer = new HASerializer(this, 10); // 10 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAObjectIdProperty), _objectId);
     _serializer->set(HASerializer::WithUniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);
+    _serializer->set(AHATOFSTR(HAStateEntityCategory), _entityCategory);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
 
     // optional property

--- a/src/device-types/HAButton.h
+++ b/src/device-types/HAButton.h
@@ -33,6 +33,15 @@ public:
         { _class = deviceClass; }
 
     /**
+     * Sets the entity category for the sensor.
+     * See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+     *
+     * @param entityCategory The category name.
+     */
+    inline void setEntityCategory(const char* entityCategory)
+        { _entityCategory = entityCategory; }
+
+    /**
      * Sets icon of the button.
      * Any icon from MaterialDesignIcons.com (for example: `mdi:home`).
      *
@@ -71,6 +80,9 @@ protected:
 private:
     /// The device class. It can be nullptr.
     const char* _class;
+
+    /// The entity category for the sensor. It can be nullptr. See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+    const char* _entityCategory;
 
     /// The icon of the button. It can be nullptr.
     const char* _icon;

--- a/src/device-types/HANumber.cpp
+++ b/src/device-types/HANumber.cpp
@@ -8,6 +8,7 @@ HANumber::HANumber(const char* uniqueId, const NumberPrecision precision) :
     HABaseDeviceType(AHATOFSTR(HAComponentNumber), uniqueId),
     _precision(precision),
     _class(nullptr),
+    _entityCategory(nullptr),
     _icon(nullptr),
     _retain(false),
     _optimistic(false),
@@ -42,11 +43,12 @@ void HANumber::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 16); // 16 - max properties nb
+    _serializer = new HASerializer(this, 17); // 17 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAObjectIdProperty), _objectId);
     _serializer->set(HASerializer::WithUniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);
+    _serializer->set(AHATOFSTR(HAStateEntityCategory), _entityCategory);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
     _serializer->set(AHATOFSTR(HAUnitOfMeasurementProperty), _unitOfMeasurement);
     _serializer->set(

--- a/src/device-types/HANumber.h
+++ b/src/device-types/HANumber.h
@@ -107,6 +107,15 @@ public:
         { _class = deviceClass; }
 
     /**
+     * Sets the entity category for the sensor.
+     * See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+     *
+     * @param entityCategory The category name.
+     */
+    inline void setEntityCategory(const char* entityCategory)
+        { _entityCategory = entityCategory; }
+
+    /**
      * Sets icon of the number.
      * Any icon from MaterialDesignIcons.com (for example: `mdi:home`).
      *
@@ -227,6 +236,9 @@ private:
 
     /// The device class. It can be nullptr.
     const char* _class;
+
+    /// The entity category for the sensor. It can be nullptr. See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+    const char* _entityCategory;
 
     /// The icon of the number. It can be nullptr.
     const char* _icon;

--- a/src/device-types/HASensor.cpp
+++ b/src/device-types/HASensor.cpp
@@ -8,6 +8,7 @@ HASensor::HASensor(const char* uniqueId, const uint16_t features) :
     HABaseDeviceType(AHATOFSTR(HAComponentSensor), uniqueId),
     _features(features),
     _deviceClass(nullptr),
+    _entityCategory(nullptr),
     _stateClass(nullptr),
     _forceUpdate(false),
     _icon(nullptr),
@@ -46,12 +47,13 @@ void HASensor::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 13); // 13 - max properties nb
+    _serializer = new HASerializer(this, 14); // 13 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAObjectIdProperty), _objectId);
     _serializer->set(HASerializer::WithUniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _deviceClass);
     _serializer->set(AHATOFSTR(HAStateClassProperty), _stateClass);
+    _serializer->set(AHATOFSTR(HAStateEntityCategory), _entityCategory);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
     _serializer->set(AHATOFSTR(HAUnitOfMeasurementProperty), _unitOfMeasurement);
 

--- a/src/device-types/HASensor.h
+++ b/src/device-types/HASensor.h
@@ -65,6 +65,15 @@ public:
         { _deviceClass = deviceClass; }
 
     /**
+     * Sets the entity category for the sensor.
+     * See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+     *
+     * @param entityCategory The category name.
+     */
+    inline void setEntityCategory(const char* entityCategory)
+        { _entityCategory = entityCategory; }
+
+    /**
      * Sets class of the state for the long term stats.
      * See: https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics
      *
@@ -109,6 +118,9 @@ private:
 
     /// The device class. It can be nullptr.
     const char* _deviceClass;
+
+    /// The entity category for the sensor. It can be nullptr. See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+    const char* _entityCategory;
 
     /// The state class for the long term stats. It can be nullptr. See: https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics
     const char* _stateClass;

--- a/src/utils/HADictionary.cpp
+++ b/src/utils/HADictionary.cpp
@@ -42,6 +42,7 @@ const char HAUniqueIdProperty[] PROGMEM = {"uniq_id"};
 const char HAObjectIdProperty[] PROGMEM = {"obj_id"};
 const char HADeviceProperty[] PROGMEM = {"dev"};
 const char HADeviceClassProperty[] PROGMEM = {"dev_cla"};
+const char HAStateEntityCategory[] PROGMEM = {"ent_cat"};
 const char HAStateClassProperty[] PROGMEM = {"stat_cla"};
 const char HAIconProperty[] PROGMEM = {"ic"};
 const char HARetainProperty[] PROGMEM = {"ret"};

--- a/src/utils/HADictionary.h
+++ b/src/utils/HADictionary.h
@@ -42,6 +42,7 @@ extern const char HAUniqueIdProperty[];
 extern const char HAObjectIdProperty[];
 extern const char HADeviceProperty[];
 extern const char HADeviceClassProperty[];
+extern const char HAStateEntityCategory[];
 extern const char HAStateClassProperty[];
 extern const char HAIconProperty[];
 extern const char HARetainProperty[];


### PR DESCRIPTION
This adds another option to certain sensors called `setEntityCategory`.  There is no checking on the `char` values, as Home Assistant will just ignore them if you set them to anything other than `config` or `diagnostic`.  I ended up only doing a handful of sensors because most of the rest of the sensors don't make any sense as configs or diagnostics.  So this option only exists for the following sensors:

- sensor
- binary sensor
- button
- number

Here's what it looks like in HA when you setup some diagnostic sensors:

<img width="336" alt="Screenshot 2024-03-02 at 7 09 11 AM" src="https://github.com/dawidchyrzynski/arduino-home-assistant/assets/1402018/94457247-5bb5-46d8-b2e3-e11bed443dd3">
