### PR TITLE
Add state class support to HABinarySensor

### DIFF
--- a/src/device-types/HABinarySensor.cpp
+++ b/src/device-types/HABinarySensor.cpp
@@ -6,7 +6,8 @@
 
 HABinarySensor::HABinarySensor(const char* uniqueId) :
     HABaseDeviceType(AHATOFSTR(HAComponentBinarySensor), uniqueId),
-    _class(nullptr),
+    _deviceClass(nullptr),
+    _stateClass(nullptr),
     _icon(nullptr),
     _currentState(false)
 {
@@ -42,11 +43,12 @@ void HABinarySensor::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 9); // 9 - max properties nb
+    _serializer = new HASerializer(this, 10); // 10 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAObjectIdProperty), _objectId);
     _serializer->set(HASerializer::WithUniqueId);
-    _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);
+    _serializer->set(AHATOFSTR(HADeviceClassProperty), _deviceClass);
+    _serializer->set(AHATOFSTR(HAStateClassProperty), _stateClass);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
 
     if (_expireAfter.isSet()) {

--- a/src/device-types/HABinarySensor.h
+++ b/src/device-types/HABinarySensor.h
@@ -61,7 +61,17 @@ public:
      * @param deviceClass The class name.
      */
     inline void setDeviceClass(const char* deviceClass)
-        { _class = deviceClass; }
+        { _deviceClass = deviceClass; }
+
+    /**
+     * Sets class of the state for the long term stats.
+     * You can find list of available values here: https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes
+     * See: https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics
+     *
+     * @param stateClass The state class name.
+     */
+    inline void setStateClass(const char* stateClass)
+        { _stateClass = stateClass; }
 
     /**
      * Sets icon of the sensor.
@@ -86,7 +96,10 @@ private:
     bool publishState(bool state);
 
     /// The device class. It can be nullptr.
-    const char* _class;
+    const char* _deviceClass;
+
+    /// The state class. It can be nullptr.
+    const char* _stateClass;
 
     /// The icon of the sensor. It can be nullptr.
     const char* _icon;

--- a/src/device-types/HASensor.h
+++ b/src/device-types/HASensor.h
@@ -66,9 +66,10 @@ public:
 
     /**
      * Sets class of the state for the long term stats.
+     * You can find list of available values here: https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes
      * See: https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics
      *
-     * @param stateClass The class name.
+     * @param stateClass The state class name.
      */
     inline void setStateClass(const char* stateClass)
         { _stateClass = stateClass; }


### PR DESCRIPTION
In b1eeec0856fca3354bdefc369b54287a24ff7f4d (#179) support was added for long-term statistics of sensors.  HomeAssistant also supports long-term statistics on *binary* sensors.  This patch adds that.