### PR TITLE
Add setConfig to call publishConfig for dynamically created device types

### DIFF
--- a/src/device-types/HABaseDeviceType.cpp
+++ b/src/device-types/HABaseDeviceType.cpp
@@ -26,6 +26,11 @@ void HABaseDeviceType::setAvailability(bool online)
     publishAvailability();
 }
 
+void HABaseDeviceType::setConfig()
+{
+    publishConfig();
+}
+
 HAMqtt* HABaseDeviceType::mqtt()
 {
     return HAMqtt::instance();

--- a/src/device-types/HABaseDeviceType.h
+++ b/src/device-types/HABaseDeviceType.h
@@ -104,6 +104,11 @@ public:
      */
     virtual void setAvailability(bool online);
 
+    /**
+     * Publishes configuration of this device type on the HA discovery topic.
+     */
+    virtual void setConfig();
+
 #ifdef ARDUINOHA_TEST
     inline HASerializer* getSerializer() const
         { return _serializer; }


### PR DESCRIPTION
Add a public wrapper called setConfig() to allow calling the protected publishConfig() during loop(). This appears to be necessary in order to set the icon, name, etc. on a dynamically created HASensor in the main loop.

My use case is a base station and multiple sensor nodes. The base station dynamically creates a new HASensor each time it receives a message from a sensor node with an ID it hasn't seen before.