### PR TITLE
Ability to use strings stored in flash.

### DIFF
--- a/src/HADevice.cpp
+++ b/src/HADevice.cpp
@@ -64,14 +64,29 @@ void HADevice::setManufacturer(const char* manufacturer)
     _serializer->set(AHATOFSTR(HADeviceManufacturerProperty), manufacturer);
 }
 
+void HADevice::setManufacturer(const __FlashStringHelper* manufacturer)
+{
+    _serializer->set(AHATOFSTR(HADeviceManufacturerProperty), manufacturer, HASerializer::ProgmemPropertyValue);
+}
+
 void HADevice::setModel(const char* model)
 {
     _serializer->set(AHATOFSTR(HADeviceModelProperty), model);
 }
 
+void HADevice::setModel(const __FlashStringHelper* model)
+{
+    _serializer->set(AHATOFSTR(HADeviceModelProperty), model, HASerializer::ProgmemPropertyValue);
+}
+
 void HADevice::setName(const char* name)
 {
     _serializer->set(AHATOFSTR(HANameProperty), name);
+}
+
+void HADevice::setName(const __FlashStringHelper* name)
+{
+    _serializer->set(AHATOFSTR(HANameProperty), name, HASerializer::ProgmemPropertyValue);
 }
 
 void HADevice::setSoftwareVersion(const char* softwareVersion)
@@ -82,11 +97,29 @@ void HADevice::setSoftwareVersion(const char* softwareVersion)
     );
 }
 
+void HADevice::setSoftwareVersion(const __FlashStringHelper* softwareVersion)
+{
+    _serializer->set(
+        AHATOFSTR(HADeviceSoftwareVersionProperty),
+        softwareVersion,
+        HASerializer::ProgmemPropertyValue
+    );
+}
+
 void HADevice::setConfigurationUrl(const char* url)
 {
     _serializer->set(
         AHATOFSTR(HADeviceConfigurationUrlProperty),
         url
+    );
+}
+
+void HADevice::setConfigurationUrl(const __FlashStringHelper* url)
+{
+    _serializer->set(
+        AHATOFSTR(HADeviceConfigurationUrlProperty),
+        url,
+        HASerializer::ProgmemPropertyValue
     );
 }
 

--- a/src/HADevice.h
+++ b/src/HADevice.h
@@ -104,11 +104,25 @@ public:
     void setManufacturer(const char* manufacturer);
 
     /**
+     * Sets the "manufacturer" property that's going to be displayed in the Home Assistant.
+     *
+     * @param manufacturer Any string. Data must reside in flash. Use PROGMEM or 'F()' macro.
+     */
+    void setManufacturer(const __FlashStringHelper* manufacturer);
+
+    /**
      * Sets the "model" property that's going to be displayed in the Home Assistant.
      *
      * @param model Any string. Keep it short to save the memory.
      */
     void setModel(const char* model);
+
+    /**
+     * Sets the "model" property that's going to be displayed in the Home Assistant.
+     *
+     * @param model Any string. Data must reside in flash. Use PROGMEM or 'F()' macro.
+     */
+    void setModel(const __FlashStringHelper* model);
 
     /**
      * Sets the "name" property that's going to be displayed in the Home Assistant.
@@ -118,6 +132,13 @@ public:
     void setName(const char* name);
 
     /**
+     * Sets the "name" property that's going to be displayed in the Home Assistant.
+     *
+     * @param name Any string. Data must reside in flash. Use PROGMEM or 'F()' macro.
+     */
+    void setName(const __FlashStringHelper* name);
+
+    /**
      * Sets the "software version" property that's going to be displayed in the Home Assistant.
      *
      * @param softwareVersion Any string. Keep it short to save the memory.
@@ -125,11 +146,25 @@ public:
     void setSoftwareVersion(const char* softwareVersion);
 
     /**
+     * Sets the "software version" property that's going to be displayed in the Home Assistant.
+     *
+     * @param softwareVersion Any string. Data must reside in flash. Use PROGMEM or 'F()' macro.
+     */
+    void setSoftwareVersion(const __FlashStringHelper* softwareVersion);
+
+    /**
      * Sets the "configuration URL" property that's going to be used by the Home Assistant.
      *
      * @param url Configuration URL to publish.
      */
     void setConfigurationUrl(const char* url);
+
+    /**
+     * Sets the "configuration URL" property that's going to be used by the Home Assistant.
+     *
+     * @param url Configuration URL to publish. Data must reside in flash. Use PROGMEM or 'F()' macro.
+     */
+    void setConfigurationUrl(const __FlashStringHelper* url);
 
     /**
      * Sets device's availability and publishes MQTT message on the availability topic.


### PR DESCRIPTION
Hi,

I saw an easy way to save a few bytes of memory by using PROGMEM data for some fields.
Saves a bit of memory depending on how long these fields are. 
No breaking change.

Obviously it could be expanded to other fields but it's a start.

Tested working on my Arduino Uno device previously running ArduinoHA 2.1.0 stock.