### PR TITLE
Increased usage of PROGMEM string

### DIFF
--- a/src/ArduinoHADefines.h
+++ b/src/ArduinoHADefines.h
@@ -33,6 +33,14 @@
     #define ARDUINOHA_DEBUG_PRINT(x)
 #endif
 
+// Define macro at project-level to maximise usage of PROGMEM strings
+// Write your code accordingly
+#if defined(ARDUINOHA_MAXPROGMEM_STRINGS)
+    #define STRING_TYPE_T __FlashStringHelper
+#else
+    #define STRING_TYPE_T char
+#endif
+
 
 #if defined(__SAMD21G18A__) or defined(__SAM3X8E__)
     #define ARDUINOHA_INT_OVERLOAD

--- a/src/device-types/HABaseDeviceType.h
+++ b/src/device-types/HABaseDeviceType.h
@@ -68,14 +68,14 @@ public:
      *
      * @param name The device type name.
      */
-    inline void setName(const char* name)
+    inline void setName(const STRING_TYPE_T* name)
         { _name = name; }
 
     /**
      * Returns name of the deviced type that was assigned via setName method.
      * It can be nullptr if there is no name assigned.
      */
-    inline const char* getName() const
+    inline const STRING_TYPE_T* getName() const
         { return _name; }
 
     /**
@@ -84,14 +84,14 @@ public:
      *
      * @param objectId The object ID.
      */
-    inline void setObjectId(const char* objectId)
+    inline void setObjectId(const STRING_TYPE_T* objectId)
         { _objectId = objectId; }
 
     /**
      * Returns the object ID that was set by setObjectId method.
      * It can be nullptr if there is no ID assigned.
      */
-    inline const char* getObjectId() const
+    inline const STRING_TYPE_T* getObjectId() const
         { return _objectId; }
 
     /**
@@ -223,10 +223,10 @@ protected:
     const char* _uniqueId;
 
     /// The name that was set using setName method. It can be nullptr.
-    const char* _name;
+    const STRING_TYPE_T* _name;
 
     /// The object ID that was set using setObjectId method. It can be nullptr.
-    const char* _objectId;
+    const STRING_TYPE_T* _objectId;
 
     /// HASerializer that belongs to this device type. It can be nullptr.
     HASerializer* _serializer;

--- a/src/device-types/HABinarySensor.h
+++ b/src/device-types/HABinarySensor.h
@@ -60,7 +60,7 @@ public:
      *
      * @param deviceClass The class name.
      */
-    inline void setDeviceClass(const char* deviceClass)
+    inline void setDeviceClass(const STRING_TYPE_T* deviceClass)
         { _class = deviceClass; }
 
     /**
@@ -69,7 +69,7 @@ public:
      *
      * @param icon The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
 protected:
@@ -86,10 +86,10 @@ private:
     bool publishState(bool state);
 
     /// The device class. It can be nullptr.
-    const char* _class;
+    const STRING_TYPE_T* _class;
 
     /// The icon of the sensor. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
 
     /// It defines the number of seconds after the sensor’s state expires, if it’s not updated. By default the sensors state never expires.
     HANumeric _expireAfter;

--- a/src/device-types/HAButton.h
+++ b/src/device-types/HAButton.h
@@ -29,7 +29,7 @@ public:
      *
      * @param deviceClass The class name.
      */
-    inline void setDeviceClass(const char* deviceClass)
+    inline void setDeviceClass(const STRING_TYPE_T* deviceClass)
         { _class = deviceClass; }
 
     /**
@@ -38,7 +38,7 @@ public:
      *
      * @param icon The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
     /**
@@ -70,10 +70,10 @@ protected:
 
 private:
     /// The device class. It can be nullptr.
-    const char* _class;
+    const STRING_TYPE_T* _class;
 
     /// The icon of the button. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
 
     /// The retain flag for the HA commands.
     bool _retain;

--- a/src/device-types/HACamera.h
+++ b/src/device-types/HACamera.h
@@ -52,7 +52,7 @@ public:
      *
      * @param icon The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
 protected:
@@ -69,7 +69,7 @@ private:
     ImageEncoding _encoding;
 
     /// The icon of the camera. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
     
 };
 

--- a/src/device-types/HACover.h
+++ b/src/device-types/HACover.h
@@ -107,7 +107,7 @@ public:
      *
      * @param deviceClass The class name.
      */
-    inline void setDeviceClass(const char* deviceClass)
+    inline void setDeviceClass(const STRING_TYPE_T* deviceClass)
         { _class = deviceClass; }
 
     /**
@@ -116,7 +116,7 @@ public:
      *
      * @param icon The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
     /**
@@ -191,10 +191,10 @@ private:
     int16_t _currentPosition;
 
     /// The device class. It can be nullptr.
-    const char* _class;
+    const STRING_TYPE_T* _class;
 
     /// The icon of the button. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
 
     /// The retain flag for the HA commands.
     bool _retain;

--- a/src/device-types/HADeviceTracker.h
+++ b/src/device-types/HADeviceTracker.h
@@ -71,7 +71,7 @@ public:
      *
      * @param icon The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
     /**
@@ -101,7 +101,7 @@ private:
     const __FlashStringHelper* getSourceTypeProperty() const;
 
     /// The icon of the tracker. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
 
     /// The source type of the tracker. By default it's `HADeviceTracker::SourceTypeUnknown`.
     SourceType _sourceType;

--- a/src/device-types/HAFan.h
+++ b/src/device-types/HAFan.h
@@ -106,7 +106,7 @@ public:
      *
      * @param icon The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
     /**
@@ -214,7 +214,7 @@ private:
     const uint8_t _features;
 
     /// The icon of the button. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
 
     /// The retain flag for the HA commands.
     bool _retain;

--- a/src/device-types/HAHVAC.h
+++ b/src/device-types/HAHVAC.h
@@ -395,7 +395,7 @@ public:
      *
      * @param icon The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
     /**
@@ -625,7 +625,7 @@ private:
     const NumberPrecision _precision;
 
     /// The icon of the button. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
 
     /// The retain flag for the HA commands.
     bool _retain;

--- a/src/device-types/HALight.h
+++ b/src/device-types/HALight.h
@@ -208,7 +208,7 @@ public:
      *
      * @param icon The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
     /**
@@ -375,7 +375,7 @@ private:
     const uint8_t _features;
 
     /// The icon of the button. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
 
     /// The retain flag for the HA commands.
     bool _retain;

--- a/src/device-types/HALock.h
+++ b/src/device-types/HALock.h
@@ -71,7 +71,7 @@ public:
      *
      * @param icon The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
     /**
@@ -129,7 +129,7 @@ private:
     void handleCommand(const uint8_t* cmd, const uint16_t length);
 
     /// The icon of the lock. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
 
     /// The retain flag for the HA commands.
     bool _retain;

--- a/src/device-types/HANumber.h
+++ b/src/device-types/HANumber.h
@@ -103,7 +103,7 @@ public:
      *
      * @param deviceClass The class name.
      */
-    inline void setDeviceClass(const char* deviceClass)
+    inline void setDeviceClass(const STRING_TYPE_T* deviceClass)
         { _class = deviceClass; }
 
     /**
@@ -112,7 +112,7 @@ public:
      *
      * @param icon The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
     /**
@@ -149,7 +149,7 @@ public:
      *
      * @param units For example: °C, %
      */
-    inline void setUnitOfMeasurement(const char* unitOfMeasurement)
+    inline void setUnitOfMeasurement(const STRING_TYPE_T* unitOfMeasurement)
         { _unitOfMeasurement = unitOfMeasurement; }
 
     /**
@@ -226,10 +226,10 @@ private:
     const NumberPrecision _precision;
 
     /// The device class. It can be nullptr.
-    const char* _class;
+    const STRING_TYPE_T* _class;
 
     /// The icon of the number. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
 
     /// The retain flag for the HA commands.
     bool _retain;
@@ -241,7 +241,7 @@ private:
     Mode _mode;
 
     /// The unit of measurement for the sensor. It can be nullptr.
-    const char* _unitOfMeasurement;
+    const STRING_TYPE_T* _unitOfMeasurement;
 
     /// The minimal value that can be set from the HA panel.
     HANumeric _minValue;

--- a/src/device-types/HAScene.h
+++ b/src/device-types/HAScene.h
@@ -28,7 +28,7 @@ public:
      *
      * @param icon The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
     /**
@@ -60,7 +60,7 @@ protected:
 
 private:
     /// The icon of the scene. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
 
     /// The retain flag for the HA commands.
     bool _retain;

--- a/src/device-types/HASelect.h
+++ b/src/device-types/HASelect.h
@@ -79,7 +79,7 @@ public:
      *
      * @param icon The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
     /**
@@ -146,7 +146,7 @@ private:
     int8_t _currentState;
 
     /// The icon of the select. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
 
     /// The retain flag for the HA commands.
     bool _retain;

--- a/src/device-types/HASensor.h
+++ b/src/device-types/HASensor.h
@@ -61,7 +61,7 @@ public:
      *
      * @param deviceClass The class name.
      */
-    inline void setDeviceClass(const char* deviceClass)
+    inline void setDeviceClass(const STRING_TYPE_T* deviceClass)
         { _deviceClass = deviceClass; }
 
     /**
@@ -70,7 +70,7 @@ public:
      *
      * @param stateClass The class name.
      */
-    inline void setStateClass(const char* stateClass)
+    inline void setStateClass(const STRING_TYPE_T* stateClass)
         { _stateClass = stateClass; }
 
     /**
@@ -88,7 +88,7 @@ public:
      *
      * @param class The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
     /**
@@ -96,7 +96,7 @@ public:
      *
      * @param units For example: °C, %
      */
-    inline void setUnitOfMeasurement(const char* unitOfMeasurement)
+    inline void setUnitOfMeasurement(const STRING_TYPE_T* unitOfMeasurement)
         { _unitOfMeasurement = unitOfMeasurement; }
 
 protected:
@@ -108,19 +108,19 @@ private:
     const uint16_t _features;
 
     /// The device class. It can be nullptr.
-    const char* _deviceClass;
+    const STRING_TYPE_T* _deviceClass;
 
     /// The state class for the long term stats. It can be nullptr. See: https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics
-    const char* _stateClass;
+    const STRING_TYPE_T* _stateClass;
 
     /// The force update flag for the HA panel.
     bool _forceUpdate;
 
     /// The icon of the sensor. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
 
     /// The unit of measurement for the sensor. It can be nullptr.
-    const char* _unitOfMeasurement;
+    const STRING_TYPE_T* _unitOfMeasurement;
 
     /// It defines the number of seconds after the sensor’s state expires, if it’s not updated. By default the sensors state never expires.
     HANumeric _expireAfter;

--- a/src/device-types/HASwitch.h
+++ b/src/device-types/HASwitch.h
@@ -68,7 +68,7 @@ public:
      *
      * @param deviceClass The class name.
      */
-    inline void setDeviceClass(const char* deviceClass)
+    inline void setDeviceClass(const STRING_TYPE_T* deviceClass)
         { _class = deviceClass; }
 
     /**
@@ -77,7 +77,7 @@ public:
      *
      * @param icon The icon name.
      */
-    inline void setIcon(const char* icon)
+    inline void setIcon(const STRING_TYPE_T* icon)
         { _icon = icon; }
 
     /**
@@ -128,10 +128,10 @@ private:
     bool publishState(const bool state);
 
     /// The device class. It can be nullptr.
-    const char* _class;
+    const STRING_TYPE_T* _class;
 
     /// The icon of the button. It can be nullptr.
-    const char* _icon;
+    const STRING_TYPE_T* _icon;
 
     /// The retain flag for the HA commands.
     bool _retain;

--- a/src/utils/HASerializer.cpp
+++ b/src/utils/HASerializer.cpp
@@ -187,6 +187,22 @@ void HASerializer::set(
     entry->value = value;
 }
 
+void HASerializer::set(
+    const __FlashStringHelper* property,
+    const __FlashStringHelper* value
+)
+{
+    if (!property || !value) {
+        return;
+    }
+
+    SerializerEntry* entry = addEntry();
+    entry->type = PropertyEntryType;
+    entry->subtype = static_cast<uint8_t>(ProgmemPropertyValue);
+    entry->property = property;
+    entry->value = value;
+}
+
 void HASerializer::set(const FlagType flag)
 {
     if (flag == WithDevice || flag == WithUniqueId) {

--- a/src/utils/HASerializer.h
+++ b/src/utils/HASerializer.h
@@ -173,6 +173,17 @@ public:
     );
 
     /**
+     * Adds a new entry to the serialized with a predefined type of `ProgmemPropertyValue`.
+     *
+     * @param property Pointer to the name of the property (progmem string).
+     * @param value Pointer to the value that's being set (progmem string).
+     */
+    void set(
+        const __FlashStringHelper* property,
+        const __FlashStringHelper* value
+    );
+
+    /**
      * Adds a new entry to the serializer with a type of `FlagEntryType`.
      *
      * @param flag Flag to add.


### PR DESCRIPTION
Even more flash strings.
In my project, it saved me 154 bytes of memory (10 binary sensors with minimal setup).

Defined at compile time this time with `ARDUINOHA_MAXPROGMEM_STRINGS` define 
I originally wanted to go for something dynamic but using a global defined macro is cleaner (and easier!)
Feel free to suggest define names. I'm bad at coming up with names.

Saves a good chunk of memory
No breaking change

Tested on my custom project, only with BinarySensor devices tho...