### PR TITLE
Add support for alarm_control_panel and add enable_by_default and entity_category support to relevant devices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-This fork adds core support for the alarm_control_panel entity, including arm/disarm code validation, and a corresponding example ino.
-
-This change also adds the enable_by_default and entity_category properties to the most common entities (sensor, number, binary_sensory, button, select). This is useful for adding configuration and control entities that are correctly categorized and exposed in the device UI in HA, as well as enabling you to hide them by default (if, for example, most people wouldn't need access to them but can enable access themselves after discovery.)
-
-
 # Arduino Home Assistant integration 🏠
 
 [![](https://img.shields.io/github/v/release/dawidchyrzynski/arduino-home-assistant?label=Version)](https://github.com/dawidchyrzynski/arduino-home-assistant/releases)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ but I successfully use it on ESP8266/ESP8255 boards in my projects.
 
 |Example|Description                  |
 |-------|-----------------------------|
+|[Alarm control panel](examples/alarm-control-panel/alarm-control-panel.ino)|Using the alarm control panel for basic arm away, arm home, and disarm support.|
 |[Binary sensor](examples/binary-sensor/binary-sensor.ino)|Using the binary sensor as a door contact sensor.|
 |[Button](examples/button/button.ino)|Adding simple buttons to the Home Assistant panel.|
 |[Camera](examples/esp32-cam/esp32-cam.ino)|Publishing the preview from the ESP32-CAM module.|

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+This fork adds core support for the alarm_control_panel entity, including arm/disarm code validation, and a corresponding example ino.
+
+This change also adds the enable_by_default and entity_category properties to the most common entities (sensor, number, binary_sensory, button, select). This is useful for adding configuration and control entities that are correctly categorized and exposed in the device UI in HA, as well as enabling you to hide them by default (if, for example, most people wouldn't need access to them but can enable access themselves after discovery.)
+
+
 # Arduino Home Assistant integration 🏠
 
 [![](https://img.shields.io/github/v/release/dawidchyrzynski/arduino-home-assistant?label=Version)](https://github.com/dawidchyrzynski/arduino-home-assistant/releases)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ but I successfully use it on ESP8266/ESP8255 boards in my projects.
 
 | Home Assistant type | Supported |
 | ------------------- | :--------: |
-| Alarm control panel |     ❌     |
+| Alarm control panel |     ✅     |
 | Binary sensor       |     ✅     |
 | Button              |     ✅     |
 | Camera              |     ✅     |

--- a/examples/alarm-control-panel/alarm-control-panel.ino
+++ b/examples/alarm-control-panel/alarm-control-panel.ino
@@ -1,0 +1,81 @@
+#include <Ethernet.h>
+#include <ArduinoHA.h>
+
+#define BROKER_ADDR     IPAddress(192,168,0,17)
+
+byte mac[] = {0x00, 0x10, 0xFA, 0x6E, 0x38, 0x4A};
+
+EthernetClient client;
+HADevice device(mac, sizeof(mac));
+HAMqtt mqtt(client, device);
+
+// "myAlarmPanel" is the unique ID of the panel. Here we also specify what capabilities we want HA to present to the user.
+HAAlarmControlPanel panel("myAlarmPanel", HAAlarmControlPanel::ArmAway | HAAlaramControlPanel::ArmHome | HAAlarmControlPanel::Trigger);
+
+// The command callback that gets called when the user interacts with the panel in HA. Here's where we modify the real alarm 
+// panel state and then report back to HA.
+void onPanelCommand(const uint8_t* cmd, const uint16_t length, HAAlarmControlPanel* sender)
+{
+    if (sender == &panel) {
+      // We know which instance was commanded. Here we would inspect the payload and take action
+      if (cmd && cmd[0] == 'A') {
+        // Arm the panel here
+
+        // Then tell HA we've armed
+        panel.setPanelState(HAAlarmControlPanel::ArmedAway);
+      }
+      else if (cmd && cmd[0] == 'H') {
+        // Arm the panel here
+
+        // Then tell HA we've armed
+        panel.setPanelState(HAAlarmControlPanel::ArmedHome);
+      }
+      else if (cmd && cmd[0] == 'T') {
+        // Trigger the alarm here
+
+        // Then tell HA we've triggered the alarm
+        panel.setPanelState(HAAlarmControlPanel::Triggered);
+      }
+      else if (cmd && cmd[0] == 'D') {
+        // Disarm the panel here
+
+        // Then tell HA we've disarmed the alarm
+        panel.setPanelState(HAAlarmControlPanel::Disarmed);
+      }
+    }
+}
+
+void setup() {
+    // you don't need to verify return status
+    Ethernet.begin(mac);
+
+    // optional device details
+    device.setName("Arduino");
+    device.setSoftwareVersion("1.0.0");
+
+    // optional properties
+    panel.setIcon("mdi:fire");
+    panel.setName("Security System");
+    panel.setPayloadArmAway("A");
+    panel.setPayloadArmHome("H");
+    panel.setPayloadTrigger("T");
+    panel.setPayloadDisarm("D");
+    panel.setCodeArmRequired(false);
+    panel.setCodeDisarmRequired(false);
+    panel.setCodeTriggerRequired(true);
+    panel.setCode("1234");
+    panel.setRetain(true);
+    
+    // command callback. called when the user interacts with the panel in HA.
+    panel.onCommand(onPanelCommand);
+
+    // Set the initial state
+    panel.setPanelState(HAAlarmControlPanel::Disarmed, true);
+
+    mqtt.begin(BROKER_ADDR);
+}
+
+void loop() {
+    Ethernet.maintain();
+    mqtt.loop();
+}

--- a/examples/alarm-control-panel/alarm-control-panel.ino
+++ b/examples/alarm-control-panel/alarm-control-panel.ino
@@ -10,7 +10,7 @@ HADevice device(mac, sizeof(mac));
 HAMqtt mqtt(client, device);
 
 // "myAlarmPanel" is the unique ID of the panel. Here we also specify what capabilities we want HA to present to the user.
-HAAlarmControlPanel panel("myAlarmPanel", HAAlarmControlPanel::ArmAway | HAAlaramControlPanel::ArmHome | HAAlarmControlPanel::Trigger);
+HAAlarmControlPanel panel("myAlarmPanel", HAAlarmControlPanel::ArmAway | HAAlarmControlPanel::ArmHome | HAAlarmControlPanel::Trigger);
 
 // The command callback that gets called when the user interacts with the panel in HA. Here's where we modify the real alarm 
 // panel state and then report back to HA.

--- a/src/ArduinoHA.h
+++ b/src/ArduinoHA.h
@@ -3,6 +3,7 @@
 
 #include "HADevice.h"
 #include "HAMqtt.h"
+#include "device-types/HAAlarmControlPanel.h"
 #include "device-types/HABinarySensor.h"
 #include "device-types/HAButton.h"
 #include "device-types/HACamera.h"

--- a/src/device-types/HAAlarmControlPanel.cpp
+++ b/src/device-types/HAAlarmControlPanel.cpp
@@ -22,17 +22,11 @@ HAAlarmControlPanel::HAAlarmControlPanel(
     _entityCategory(nullptr),
     _commandCallback(nullptr),
     _payloadArmAway(nullptr),
-    _armAwayCallback(nullptr),
     _payloadArmHome(nullptr),
-    _armHomeCallback(nullptr),
     _payloadArmNight(nullptr),
-    _armNightCallback(nullptr),
     _payloadArmVacation(nullptr),
-    _armVacationCallback(nullptr),
     _payloadDisarm(nullptr),
-    _disarmCallback(nullptr),
-    _payloadTrigger(nullptr),
-    _triggerCallback(nullptr)
+    _payloadTrigger(nullptr)
 {
     _supportedFeaturesSerializer = new HASerializerArray(4);
 }

--- a/src/device-types/HAAlarmControlPanel.cpp
+++ b/src/device-types/HAAlarmControlPanel.cpp
@@ -1,0 +1,227 @@
+#include "HAAlarmControlPanel.h"
+#ifndef EX_ARDUINOHA_ALARMPANEL
+
+#include "../HAMqtt.h"
+#include "../utils/HAUtils.h"
+#include "../utils/HASerializer.h"
+
+HAAlarmControlPanel::HAAlarmControlPanel(
+    const char* uniqueId,
+    const uint16_t features
+) :
+    HABaseDeviceType(AHATOFSTR(HAComponentAlarmControlPanel), uniqueId),
+    _features(features),
+    _icon(nullptr),
+    _retain(false),
+    _panelState(UnknownState),
+    _code(nullptr),
+    _codeArmRequired(true),
+    _codeDisarmRequired(true),
+    _codeTriggerRequired(true),
+    _enableByDefault(true),
+    _entityCategory(nullptr),
+    _commandCallback(nullptr),
+    _payloadArmAway(nullptr),
+    _armAwayCallback(nullptr),
+    _payloadArmHome(nullptr),
+    _armHomeCallback(nullptr),
+    _payloadArmNight(nullptr),
+    _armNightCallback(nullptr),
+    _payloadArmVacation(nullptr),
+    _armVacationCallback(nullptr),
+    _payloadDisarm(nullptr),
+    _disarmCallback(nullptr),
+    _payloadTrigger(nullptr),
+    _triggerCallback(nullptr)
+{
+    _supportedFeaturesSerializer = new HASerializerArray(4);
+}
+
+HAAlarmControlPanel::~HAAlarmControlPanel()
+{
+    if (_supportedFeaturesSerializer) {
+        delete _supportedFeaturesSerializer;
+    }
+}
+
+bool HAAlarmControlPanel::setPanelState(const PanelState state, const bool force)
+{
+    if (!force && state == _panelState) {
+        return true;
+    }
+
+    if (publishPanelState(state)) {
+        _panelState = state;
+        return true;
+    }
+
+    return false;
+}
+
+void HAAlarmControlPanel::buildSerializer()
+{
+    if (_serializer || !uniqueId()) {
+        return;
+    }
+
+    _serializer = new HASerializer(this, 21); // 21 - max properties nb
+    _serializer->set(AHATOFSTR(HANameProperty), _name);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _objectId);
+    _serializer->set(HASerializer::WithUniqueId);
+    _serializer->set(AHATOFSTR(HAIconProperty), _icon);
+
+    if (_retain) {
+        _serializer->set(
+            AHATOFSTR(HARetainProperty),
+            &_retain,
+            HASerializer::BoolPropertyType
+        );
+    }
+
+    if (!_codeArmRequired) {
+        _serializer->set(
+            AHATOFSTR(HACodeArmRequiredProperty),
+            &_codeArmRequired,
+            HASerializer::BoolPropertyType
+        );
+    }
+
+    if (!_codeDisarmRequired) {
+        _serializer->set(
+            AHATOFSTR(HACodeDisarmRequiredProperty),
+            &_codeDisarmRequired,
+            HASerializer::BoolPropertyType
+        );
+    }
+
+    if (!_codeTriggerRequired) {
+        _serializer->set(
+            AHATOFSTR(HACodeTriggerRequiredProperty),
+            &_codeTriggerRequired,
+            HASerializer::BoolPropertyType
+        );
+    }
+
+    if (_code) {
+        _serializer->set(AHATOFSTR(HACodeProperty), _code);
+    }
+
+
+    // Supported features
+    if (_features != DefaultFeatures) {
+        _supportedFeaturesSerializer->clear();
+
+        if (_features & ArmAway) {
+            _supportedFeaturesSerializer->add(HAArmAway);
+        }
+
+        if (_features & ArmHome) {
+            _supportedFeaturesSerializer->add(HAArmHome);
+        }
+
+        if (_features & ArmNight) {
+            _supportedFeaturesSerializer->add(HAArmNight);
+        }
+
+        if (_features & ArmVacation) {
+            _supportedFeaturesSerializer->add(HAArmVacation);
+        }
+
+        if (_features & ArmCustomBypass) {
+            _supportedFeaturesSerializer->add(HAArmCustomBypass);
+        }
+
+        if (_features & Trigger) {
+            _supportedFeaturesSerializer->add(HATrigger);
+        }
+
+        _serializer->set(
+            AHATOFSTR(HASupportedFeaturesProperty),
+            _supportedFeaturesSerializer,
+            HASerializer::ArrayPropertyType
+        );
+    }
+
+    _serializer->topic(AHATOFSTR(HAStateTopic));
+    _serializer->topic(AHATOFSTR(HACommandTopic));
+    _serializer->set(AHATOFSTR(HAPayloadArmAwayTopic), _payloadArmAway);
+    _serializer->set(AHATOFSTR(HAPayloadArmHomeTopic), _payloadArmHome);
+    _serializer->set(AHATOFSTR(HAPayloadArmNightTopic), _payloadArmNight);
+    _serializer->set(AHATOFSTR(HAPayloadArmVacationTopic), _payloadArmVacation);
+    _serializer->set(AHATOFSTR(HAPayloadArmCustomBypassTopic), _payloadArmCustomBypass);
+    _serializer->set(AHATOFSTR(HAPayloadDisarmTopic), _payloadDisarm);
+    _serializer->set(AHATOFSTR(HAPayloadTriggerTopic), _payloadTrigger);
+    _serializer->set(HASerializer::WithDevice);
+    _serializer->set(HASerializer::WithAvailability);
+}
+
+void HAAlarmControlPanel::onMqttConnected()
+{
+    if (!uniqueId()) {
+        return;
+    }
+
+    publishConfig();
+    publishAvailability();
+
+    subscribeTopic(uniqueId(), AHATOFSTR(HACommandTopic));
+
+    if (!_retain) {
+        publishPanelState(_panelState);
+
+
+    }
+}
+
+void HAAlarmControlPanel::onMqttMessage(
+    const char* topic,
+    const uint8_t* payload,
+    const uint16_t length
+)
+{
+    if (HASerializer::compareDataTopics(
+        topic,
+        uniqueId(),
+        AHATOFSTR(HACommandTopic)
+    )) {
+        handleCommand(payload, length);
+    }
+}
+
+bool HAAlarmControlPanel::publishPanelState(const PanelState state)
+{
+    const __FlashStringHelper* str = nullptr;
+    switch (state)
+    {
+        case ArmedAway: str = AHATOFSTR(HAStateArmedAway); break;
+        case ArmedCustomBypass: str = AHATOFSTR(HAStateArmedCustomBypass); break;
+        case ArmedHome: str = AHATOFSTR(HAStateArmedHome); break;
+        case ArmedNight: str = AHATOFSTR(HAStateArmedNight); break;
+        case ArmedVacation: str = AHATOFSTR(HAStateArmedVacation); break;
+        case Arming: str = AHATOFSTR(HAStateArming); break;
+        case Disarmed: str = AHATOFSTR(HAStateDisarmed); break;
+        case Disarming: str = AHATOFSTR(HAStateDisarming); break;
+        case UnknownState: // fallthrough
+        case Pending: str = AHATOFSTR(HAStatePending); break;
+        case Triggered: str = AHATOFSTR(HAStateTriggered); break;
+    }
+
+    return publishOnDataTopic(
+        AHATOFSTR(HAStateTopic),
+        str,
+        true
+    );
+}
+
+void HAAlarmControlPanel::handleCommand(const uint8_t* cmd, const uint16_t length)
+{
+    (void)cmd;
+
+    if (!_commandCallback) {
+        return;
+    }
+
+    _commandCallback(cmd, length, this);
+}
+
+#endif

--- a/src/device-types/HAAlarmControlPanel.h
+++ b/src/device-types/HAAlarmControlPanel.h
@@ -1,0 +1,311 @@
+#ifndef AHA_HAALARMPANEL_H
+#define AHA_HAALARMPANEL_H
+
+#include "HABaseDeviceType.h"
+
+#ifndef EX_ARDUINOHA_ALARMPANEL
+
+#define HAALARMPANEL_CALLBACK(name) void (*name)(const uint8_t* cmd, const uint16_t length, HAAlarmControlPanel* sender)
+
+class HASerializerArray;
+
+/**
+ * Alarm Control Panel lets you control your security system.
+ *
+ * @note
+ * You can find more information about this entity in the Home Assistant documentation:
+ * https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/
+ */
+class HAAlarmControlPanel : public HABaseDeviceType
+{
+public:
+
+    /// The list of features available in the panel. They're used in the constructor.
+    enum SupportedFeatures {
+        DefaultFeatures = 0,
+        ArmHome = 1,
+        ArmAway = 2,
+        ArmNight = 4,
+        ArmVacation = 8,
+        ArmCustomBypass = 16,
+        Trigger = 32
+    };
+
+    /// The list of possible states that the panel is set to.
+    enum PanelState {
+        UnknownState = 0,
+        Disarmed,
+        ArmedHome,
+        ArmedAway,
+        ArmedNight,
+        ArmedVacation,
+        ArmedCustomBypass,
+        Pending,
+        Triggered,
+        Arming,
+        Disarming
+    };
+
+    /**
+     * @param uniqueId The unique ID of the HVAC. It needs to be unique in a scope of your device.
+     * @param features Features that should be enabled for the panel.
+     */
+    HAAlarmControlPanel(
+        const char* uniqueId,
+        const uint16_t features = DefaultFeatures
+    );
+
+    /**
+     * Frees memory allocated for the arrays serialization.
+     */
+    ~HAAlarmControlPanel();
+
+    /**
+     * Sets the state of the alarm panel
+     *
+     * @param state The new state.
+     */
+    bool setPanelState(const PanelState state, const bool force = false);
+
+    /**
+     * Retrieves the last known state of the alarm panel
+     */
+    inline bool getPanelState() const
+        { return _panelState; }
+
+    /**
+     * Sets icon of the HVAC.
+     * Any icon from MaterialDesignIcons.com (for example: `mdi:home`).
+     *
+     * @param icon The icon name.
+     */
+    inline void setIcon(const char* icon)
+        { _icon = icon; }
+
+    /**
+     * Sets retain flag for the HVAC's command.
+     * If set to `true` the command produced by Home Assistant will be retained.
+     *
+     * @param retain
+     */
+    inline void setRetain(const bool retain)
+        { _retain = retain; }
+
+    /**
+     * Sets enable by default flag for the entity.
+     * If set to `false` the entity will be disabled when added to Home Assisant. The user will have
+     * to enable it to use the entity. Useful for control entities that are convenient to have for advanced
+     * users, but most people might not need.
+     *
+     * @param enableByDefault
+     */
+    inline void setEnableByDefault(const bool enableByDefault)
+        { _enableByDefault = enableByDefault; }
+
+    /**
+     * Sets the entity category for the panel.
+     * See: https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/#entity_category
+     *
+     * @param entityCategory The category name.
+     */
+    inline void setEntityCategory(const char* entityCategory)
+        { _entityCategory = entityCategory; }
+
+    /**
+     * If defined, specifies a code to enable or disable the alarm in the frontend. Note that the code is validated
+     * locally and blocks sending MQTT messages to the remote device. 
+     * See: https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/#code
+     *
+     * @param payload The payload to be sent to activate the mode.
+     */
+    inline void setCode(const char* code)
+        { _code = code; }
+
+    /**
+     * Sets whether the code is required to arm the panel.
+     * If true, the code is required to arm the alarm. If false, the code will not be validated. Default is true.
+     *
+     * @param required
+     */
+    inline void setCodeArmRequired(const bool required)
+        { _codeArmRequired = required; }
+
+    /**
+     * Sets whether the code is required to disarm the panel.
+     * If true, the code is required to disarm the alarm. If false, the code will not be validated. Default is true.
+     *
+     * @param required
+     */
+    inline void setCodeDisarmRequired(const bool required)
+        { _codeDisarmRequired = required; }
+
+    /**
+     * Sets whether the code is required to trigger the alarm.
+     * If true, the code is required to trigger the alarm. If false, the code will not be validated. Default is true.
+     *
+     * @param required
+     */
+    inline void setCodeTriggerRequired(const bool required)
+        { _codeTriggerRequired = required; }
+
+
+    /**
+     * Sets the payload to send to the panel to arm away.
+     * See: https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/#payload_arm_away
+     *
+     * @param payload The payload to be sent to activate the mode.
+     */
+    inline void setPayloadArmAway(const char* payload)
+        { _payloadArmAway = payload; }
+
+    /**
+     * Sets the payload to send to the panel to arm home.
+     * See: https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/#payload_arm_home
+     *
+     * @param payload The payload to be sent to activate the mode.
+     */
+    inline void setPayloadArmHome(const char* payload)
+        { _payloadArmHome = payload; }
+
+    /**
+     * Sets the payload to send to the panel to arm night.
+     * See: https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/#payload_arm_night
+     *
+     * @param payload The payload to be sent to activate the mode.
+     */
+    inline void setPayloadArmNight(const char* payload)
+        { _payloadArmNight = payload; }
+    
+    /**
+     * Sets the payload to send to the panel to arm vacation.
+     * See: https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/#payload_arm_vacation
+     *
+     * @param payload The payload to be sent to activate the mode.
+     */
+    inline void setPayloadArmVacation(const char* payload)
+        { _payloadArmVacation = payload; }
+    
+    /**
+     * Sets the payload to send to the panel to arm custom bypass.
+     * See: https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/#payload_arm_custom_bypass
+     *
+     * @param payload The payload to be sent to activate the mode.
+     */
+    inline void setPayloadCustomBypass(const char* payload)
+        { _payloadArmCustomBypass = payload; }
+
+    /**
+     * Sets the payload to send to the panel to disarmit.
+     * See: https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/#payload_disarm
+     *
+     * @param payload The payload to be sent to activate the mode.
+     */
+    inline void setPayloadDisarm(const char* payload)
+        { _payloadDisarm = payload; }
+
+    /**
+     * Sets the payload to trigger the alarm.
+     * See: https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/#payload_trigger
+     *
+     * @param payload The payload to be sent to activate the mode.
+     */
+    inline void setPayloadTrigger(const char* payload)
+        { _payloadTrigger = payload; }
+
+    /**
+     * Registers callback that will be called each time the user issues a command (e.g. to arm, disarm) to the panel via HA.
+     *
+     * @param callback
+     */
+    inline void onCommand(HAALARMPANEL_CALLBACK(callback))
+        { _commandCallback = callback; }
+
+
+protected:
+
+    virtual void buildSerializer() override;
+    virtual void onMqttConnected() override;
+    virtual void onMqttMessage(
+        const char* topic,
+        const uint8_t* payload,
+        const uint16_t length
+    ) override;
+
+private:
+
+    /**
+     * Publishes the MQTT message with the given current temperature.
+     *
+     * @param state The alarm state to publish.
+     * @returns Returns `true` if the MQTT message has been published successfully.
+     */
+    bool publishPanelState(const PanelState state);
+
+    /**
+     * Parses the given command message and executes the callback with proper value.
+     *
+     * @param cmd The data of the command.
+     * @param length Length of the command.
+     */
+    void handleCommand(const uint8_t* cmd, const uint16_t length);
+
+    /// The supported features of the alarm paenl.
+    const uint16_t _features;
+
+    /// The icon of the entity. It can be nullptr.
+    const char* _icon;
+
+    /// The retain flag for the HA commands.
+    bool _retain;
+
+    /// The panel state.
+    PanelState _panelState;
+
+    /// If defined, specifies a code to enable or disable the alarm in the frontend. 
+    const char* _code;
+
+    /// If true the code is required to arm the alarm. If false the code is not validated. Default is true.
+    bool _codeArmRequired;
+
+    /// If true the code is required to diarmarm the alarm. If false the code is not validated. Default is true.
+    bool _codeDisarmRequired;
+
+    /// If true the code is required to trigger the alarm. If false the code is not validated. Default is true.
+    bool _codeTriggerRequired;
+
+    /// If true the panel is enabled when it's first added to HA. If false it is disabled when first added. Default is true.
+    bool _enableByDefault;
+
+    /// The entity category for the entity. It can be nullptr.
+    const char* _entityCategory;
+
+    /// Callback that will be called when the HA sends a command to arm, disarm, etc. Will contain the corresponding payload.
+    HAALARMPANEL_CALLBACK(_commandCallback);
+
+    /// The payload to set armed-away mode on your Alarm Panel.
+    const char* _payloadArmAway;
+
+    /// The payload to set armed-home mode on your Alarm Panel.
+    const char* _payloadArmHome;
+
+    /// The payload to set armed-night mode on your Alarm Panel.
+    const char* _payloadArmNight;
+
+    /// The payload to set armed-vacation mode on your Alarm Panel.
+    const char* _payloadArmVacation;
+
+    /// The payload to set armed-custom-bypass mode on your Alarm Panel.
+    const char* _payloadArmCustomBypass;
+
+    /// The payload to disarm your Alarm Panel.
+    const char* _payloadDisarm;
+
+    /// The payload to trigger the alarm on your Alarm Panel.
+    const char* _payloadTrigger;
+
+    /// The serializer for the supported features.
+    HASerializerArray* _supportedFeaturesSerializer;
+};
+
+#endif
+#endif

--- a/src/device-types/HABinarySensor.cpp
+++ b/src/device-types/HABinarySensor.cpp
@@ -8,6 +8,8 @@ HABinarySensor::HABinarySensor(const char* uniqueId) :
     HABaseDeviceType(AHATOFSTR(HAComponentBinarySensor), uniqueId),
     _class(nullptr),
     _icon(nullptr),
+    _enableByDefault(true),
+    _entityCategory(nullptr),
     _currentState(false)
 {
 
@@ -42,12 +44,21 @@ void HABinarySensor::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 9); // 9 - max properties nb
+    _serializer = new HASerializer(this, 11); // 11 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAObjectIdProperty), _objectId);
     _serializer->set(HASerializer::WithUniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
+    _serializer->set(AHATOFSTR(HAEntityCategory), _entityCategory);
+
+    if (!_enableByDefault) {
+        _serializer->set(
+            AHATOFSTR(HAEnabledByDefaultProperty),
+            &_enableByDefault,
+            HASerializer::BoolPropertyType
+        );
+    }
 
     if (_expireAfter.isSet()) {
         _serializer->set(

--- a/src/device-types/HABinarySensor.h
+++ b/src/device-types/HABinarySensor.h
@@ -72,6 +72,26 @@ public:
     inline void setIcon(const char* icon)
         { _icon = icon; }
 
+    /**
+     * Sets enable by default flag for the entity.
+     * If set to `false` the entity will be disabled when added to Home Assisant. The user will have
+     * to enable it to use the entity. Useful for control entities that are convenient to have for advanced
+     * users, but most people might not need.
+     *
+     * @param enableByDefault
+     */
+    inline void setEnableByDefault(const bool enableByDefault)
+        { _enableByDefault = enableByDefault; }
+
+    /**
+     * Sets the entity category for the sensor.
+     * See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+     *
+     * @param entityCategory The category name.
+     */
+    inline void setEntityCategory(const char* entityCategory)
+        { _entityCategory = entityCategory; }
+
 protected:
     virtual void buildSerializer() override;
     virtual void onMqttConnected() override;
@@ -90,6 +110,12 @@ private:
 
     /// The icon of the sensor. It can be nullptr.
     const char* _icon;
+
+    /// The enable by default property for the entity. If false, the entity will not be enabled or available to the user without first manually enabling.
+    bool _enableByDefault;
+
+    /// The entity category for the entity. It can be nullptr. See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+    const char* _entityCategory;
 
     /// It defines the number of seconds after the sensor’s state expires, if it’s not updated. By default the sensors state never expires.
     HANumeric _expireAfter;

--- a/src/device-types/HAButton.cpp
+++ b/src/device-types/HAButton.cpp
@@ -9,6 +9,8 @@ HAButton::HAButton(const char* uniqueId) :
     _class(nullptr),
     _icon(nullptr),
     _retain(false),
+    _enableByDefault(true),
+    _entityCategory(nullptr),
     _commandCallback(nullptr)
 {
 
@@ -20,12 +22,22 @@ void HAButton::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 9); // 9 - max properties nb
+    _serializer = new HASerializer(this, 11); // 10 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAObjectIdProperty), _objectId);
     _serializer->set(HASerializer::WithUniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
+    _serializer->set(AHATOFSTR(HAEntityCategory), _entityCategory);
+
+    // optional property
+    if (!_enableByDefault) {
+        _serializer->set(
+            AHATOFSTR(HAEnabledByDefaultProperty),
+            &_enableByDefault,
+            HASerializer::BoolPropertyType
+        );
+    }
 
     // optional property
     if (_retain) {

--- a/src/device-types/HAButton.h
+++ b/src/device-types/HAButton.h
@@ -42,6 +42,26 @@ public:
         { _icon = icon; }
 
     /**
+     * Sets enable by default flag for the entity.
+     * If set to `false` the entity will be disabled when added to Home Assisant. The user will have
+     * to enable it to use the entity. Useful for control entities that are convenient to have for advanced
+     * users, but most people might not need.
+     *
+     * @param enableByDefault
+     */
+    inline void setEnableByDefault(const bool enableByDefault)
+        { _enableByDefault = enableByDefault; }
+
+    /**
+     * Sets the entity category for the sensor.
+     * See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+     *
+     * @param entityCategory The category name.
+     */
+    inline void setEntityCategory(const char* entityCategory)
+        { _entityCategory = entityCategory; }
+
+    /**
      * Sets retain flag for the button's command.
      * If set to `true` the command produced by Home Assistant will be retained.
      *
@@ -77,6 +97,12 @@ private:
 
     /// The retain flag for the HA commands.
     bool _retain;
+
+    /// The enable by default property for the entity. If false, the entity will not be enabled or available to the user without first manually enabling.
+    bool _enableByDefault;
+
+    /// The entity category for the entity. It can be nullptr. See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+    const char* _entityCategory;
 
     /// The command callback that will be called once clicking the button in HA panel.
     HABUTTON_CALLBACK(_commandCallback);

--- a/src/device-types/HANumber.cpp
+++ b/src/device-types/HANumber.cpp
@@ -9,6 +9,8 @@ HANumber::HANumber(const char* uniqueId, const NumberPrecision precision) :
     _precision(precision),
     _class(nullptr),
     _icon(nullptr),
+    _entityCategory(nullptr),
+    _enableByDefault(true),
     _retain(false),
     _optimistic(false),
     _mode(ModeAuto),
@@ -42,13 +44,14 @@ void HANumber::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 16); // 16 - max properties nb
+    _serializer = new HASerializer(this, 19); // 19 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAObjectIdProperty), _objectId);
     _serializer->set(HASerializer::WithUniqueId);
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
     _serializer->set(AHATOFSTR(HAUnitOfMeasurementProperty), _unitOfMeasurement);
+    _serializer->set(AHATOFSTR(HAEntityCategory), _entityCategory);
     _serializer->set(
         AHATOFSTR(HAModeProperty),
         getModeProperty(),
@@ -81,6 +84,14 @@ void HANumber::buildSerializer()
             AHATOFSTR(HAStepProperty),
             &_step,
             HASerializer::NumberPropertyType
+        );
+    }
+
+    if (!_enableByDefault) {
+        _serializer->set(
+            AHATOFSTR(HAEnabledByDefaultProperty),
+            &_enableByDefault,
+            HASerializer::BoolPropertyType
         );
     }
 

--- a/src/device-types/HANumber.h
+++ b/src/device-types/HANumber.h
@@ -116,6 +116,26 @@ public:
         { _icon = icon; }
 
     /**
+     * Sets enable by default flag for the entity.
+     * If set to `false` the entity will be disabled when added to Home Assisant. The user will have
+     * to enable it to use the entity. Useful for control entities that are convenient to have for advanced
+     * users, but most people might not need.
+     *
+     * @param enableByDefault
+     */
+    inline void setEnableByDefault(const bool enableByDefault)
+        { _enableByDefault = enableByDefault; }
+        
+    /**
+     * Sets the entity category for the sensor.
+     * See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+     *
+     * @param entityCategory The category name.
+     */
+    inline void setEntityCategory(const char* entityCategory)
+        { _entityCategory = entityCategory; }
+
+    /**
      * Sets retain flag for the number's command.
      * If set to `true` the command produced by Home Assistant will be retained.
      *
@@ -231,6 +251,12 @@ private:
     /// The icon of the number. It can be nullptr.
     const char* _icon;
 
+    /// The entity category for the sensor. It can be nullptr. See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+    const char* _entityCategory;
+    
+    /// The Enable By Default property for the HA commands. False adds the entity in disabled state.
+    bool _enableByDefault;
+    
     /// The retain flag for the HA commands.
     bool _retain;
 

--- a/src/device-types/HASelect.cpp
+++ b/src/device-types/HASelect.cpp
@@ -9,6 +9,8 @@ HASelect::HASelect(const char* uniqueId) :
     _options(nullptr),
     _currentState(-1),
     _icon(nullptr),
+    _enableByDefault(true),
+    _entityCategory(nullptr),
     _retain(false),
     _optimistic(false),
     _commandCallback(nullptr)
@@ -96,11 +98,21 @@ void HASelect::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 11); // 11 - max properties nb
+    _serializer = new HASerializer(this, 13); // 13 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAObjectIdProperty), _objectId);
     _serializer->set(HASerializer::WithUniqueId);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
+    _serializer->set(AHATOFSTR(HAEntityCategory), _entityCategory);
+
+    if (!_enableByDefault) {
+        _serializer->set(
+            AHATOFSTR(HAEnabledByDefaultProperty),
+            &_enableByDefault,
+            HASerializer::BoolPropertyType
+        );
+    }
+
     _serializer->set(
         AHATOFSTR(HAOptionsProperty),
         _options,

--- a/src/device-types/HASelect.h
+++ b/src/device-types/HASelect.h
@@ -83,6 +83,26 @@ public:
         { _icon = icon; }
 
     /**
+     * Sets enable by default flag for the entity.
+     * If set to `false` the entity will be disabled when added to Home Assisant. The user will have
+     * to enable it to use the entity. Useful for control entities that are convenient to have for advanced
+     * users, but most people might not need.
+     *
+     * @param enableByDefault
+     */
+    inline void setEnableByDefault(const bool enableByDefault)
+        { _enableByDefault = enableByDefault; }
+
+    /**
+     * Sets the entity category for the sensor.
+     * See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+     *
+     * @param entityCategory The category name.
+     */
+    inline void setEntityCategory(const char* entityCategory)
+        { _entityCategory = entityCategory; }
+
+    /**
      * Sets retain flag for the select's command.
      * If set to `true` the command produced by Home Assistant will be retained.
      *
@@ -148,6 +168,12 @@ private:
     /// The icon of the select. It can be nullptr.
     const char* _icon;
 
+    /// The enable by default property for the entity. If false, the entity will not be enabled or available to the user without first manually enabling.
+    bool _enableByDefault;
+
+    /// The entity category for the entity. It can be nullptr. See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+    const char* _entityCategory;
+    
     /// The retain flag for the HA commands.
     bool _retain;
 

--- a/src/device-types/HASensor.cpp
+++ b/src/device-types/HASensor.cpp
@@ -11,6 +11,8 @@ HASensor::HASensor(const char* uniqueId, const uint16_t features) :
     _stateClass(nullptr),
     _forceUpdate(false),
     _icon(nullptr),
+    _enableByDefault(true),
+    _entityCategory(nullptr),
     _unitOfMeasurement(nullptr),
     _expireAfter()
 {
@@ -46,7 +48,7 @@ void HASensor::buildSerializer()
         return;
     }
 
-    _serializer = new HASerializer(this, 13); // 13 - max properties nb
+    _serializer = new HASerializer(this, 15); // 15 - max properties nb
     _serializer->set(AHATOFSTR(HANameProperty), _name);
     _serializer->set(AHATOFSTR(HAObjectIdProperty), _objectId);
     _serializer->set(HASerializer::WithUniqueId);
@@ -54,7 +56,15 @@ void HASensor::buildSerializer()
     _serializer->set(AHATOFSTR(HAStateClassProperty), _stateClass);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
     _serializer->set(AHATOFSTR(HAUnitOfMeasurementProperty), _unitOfMeasurement);
+    _serializer->set(AHATOFSTR(HAEntityCategory), _entityCategory);
 
+    if (!_enableByDefault) {
+        _serializer->set(
+            AHATOFSTR(HAEnabledByDefaultProperty),
+            &_enableByDefault,
+            HASerializer::BoolPropertyType
+        );
+    }
     if (_forceUpdate) {
         _serializer->set(
             AHATOFSTR(HAForceUpdateProperty),

--- a/src/device-types/HASensor.h
+++ b/src/device-types/HASensor.h
@@ -92,6 +92,26 @@ public:
         { _icon = icon; }
 
     /**
+     * Sets enable by default flag for the entity.
+     * If set to `false` the entity will be disabled when added to Home Assisant. The user will have
+     * to enable it to use the entity. Useful for control entities that are convenient to have for advanced
+     * users, but most people might not need.
+     *
+     * @param enableByDefault
+     */
+    inline void setEnableByDefault(const bool enableByDefault)
+        { _enableByDefault = enableByDefault; }
+
+    /**
+     * Sets the entity category for the sensor.
+     * See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+     *
+     * @param entityCategory The category name.
+     */
+    inline void setEntityCategory(const char* entityCategory)
+        { _entityCategory = entityCategory; }
+
+    /**
      * Defines the units of measurement of the sensor, if any.
      *
      * @param units For example: °C, %
@@ -118,6 +138,12 @@ private:
 
     /// The icon of the sensor. It can be nullptr.
     const char* _icon;
+
+    /// The enable by default property for the entity. If false, the entity will not be enabled or available to the user without first manually enabling.
+    bool _enableByDefault;
+
+    /// The entity category for the entity. It can be nullptr. See: https://www.home-assistant.io/integrations/sensor.mqtt/#entity_category
+    const char* _entityCategory;
 
     /// The unit of measurement for the sensor. It can be nullptr.
     const char* _unitOfMeasurement;

--- a/src/utils/HADictionary.cpp
+++ b/src/utils/HADictionary.cpp
@@ -18,6 +18,8 @@ const char HAComponentScene[] PROGMEM = {"scene"};
 const char HAComponentFan[] PROGMEM = {"fan"};
 const char HAComponentLight[] PROGMEM = {"light"};
 const char HAComponentClimate[] PROGMEM = {"climate"};
+const char HAComponentAlarmControlPanel[] PROGMEM = {"alarm_control_panel"};
+
 
 // decorators
 const char HASerializerSlash[] PROGMEM = {"/"};
@@ -75,6 +77,12 @@ const char HAModesProperty[] PROGMEM = {"modes"};
 const char HATemperatureCommandTemplateProperty[] PROGMEM = {"temp_cmd_tpl"};
 const char HAPayloadOnProperty[] PROGMEM = {"pl_on"};
 const char HAExpireAfterProperty[] PROGMEM = {"exp_aft"};
+const char HAEnabledByDefaultProperty[] PROGMEM = {"en"};
+const char HASupportedFeaturesProperty[] PROGMEM = {"sup_feat"};
+const char HACodeArmRequiredProperty[] PROGMEM = {"cod_arm_req"};
+const char HACodeDisarmRequiredProperty[] PROGMEM = {"cod_dis_req"};
+const char HACodeTriggerRequiredProperty[] PROGMEM = {"cod_trig_req"};
+const char HACodeProperty[] PROGMEM = {"code"};
 
 // topics
 const char HAConfigTopic[] PROGMEM = {"config"};
@@ -105,6 +113,13 @@ const char HATemperatureStateTopic[] PROGMEM = {"temp_stat_t"};
 const char HARGBCommandTopic[] PROGMEM = {"rgb_cmd_t"};
 const char HARGBStateTopic[] PROGMEM = {"rgb_stat_t"};
 const char HAJsonAttributesTopic[] PROGMEM = {"json_attr_t"};
+const char HAPayloadArmAwayTopic[] PROGMEM = {"pl_arm_away"};
+const char HAPayloadArmCustomBypassTopic[] PROGMEM = {"pl_arm_custom_b"};
+const char HAPayloadArmHomeTopic[] PROGMEM = {"pl_arm_home"};
+const char HAPayloadArmNightTopic[] PROGMEM = {"pl_arm_nite"};;
+const char HAPayloadArmVacationTopic[] PROGMEM = {"pl_arm_vacation"};;
+const char HAPayloadDisarmTopic[] PROGMEM = {"pl_disarm"};;
+const char HAPayloadTriggerTopic[] PROGMEM = {"pl_trig"};;
 
 // misc
 const char HAOnline[] PROGMEM = {"online"};
@@ -121,6 +136,22 @@ const char HANotHome[] PROGMEM = {"not_home"};
 const char HATrigger[] PROGMEM = {"trigger"};
 const char HAModeBox[] PROGMEM = {"box"};
 const char HAModeSlider[] PROGMEM = {"slider"};
+const char HAEntityCategory[] PROGMEM = {"ent_cat"};
+const char HAArmHome[] PROGMEM = {"arm_home"};
+const char HAArmAway[] PROGMEM = {"arm_away"};
+const char HAArmNight[] PROGMEM = {"arm_night"};
+const char HAArmVacation[] PROGMEM = {"arm_vacation"};
+const char HAArmCustomBypass[] PROGMEM = {"arm_custom_bypass"};
+const char HAStateArmedAway[] PROGMEM = {"armed_away"};
+const char HAStateArmedCustomBypass[] PROGMEM = {"armed_custom_bypass"};
+const char HAStateArmedHome[] PROGMEM = {"armed_home"};
+const char HAStateArmedNight[] PROGMEM = {"armed_night"};
+const char HAStateArmedVacation[] PROGMEM = {"armed_vacation"};
+const char HAStateArming[] PROGMEM = {"arming"};
+const char HAStateDisarmed[] PROGMEM = {"disarmed"};
+const char HAStateDisarming[] PROGMEM = {"disarming"};
+const char HAStatePending[] PROGMEM = {"pending"};
+const char HAStateTriggered[] PROGMEM = {"triggered"};
 
 // covers
 const char HAClosedState[] PROGMEM = {"closed"};

--- a/src/utils/HADictionary.h
+++ b/src/utils/HADictionary.h
@@ -18,6 +18,7 @@ extern const char HAComponentScene[];
 extern const char HAComponentFan[];
 extern const char HAComponentLight[];
 extern const char HAComponentClimate[];
+extern const char HAComponentAlarmControlPanel[];
 
 // decorators
 extern const char HASerializerSlash[];
@@ -75,6 +76,12 @@ extern const char HAModesProperty[];
 extern const char HATemperatureCommandTemplateProperty[];
 extern const char HAPayloadOnProperty[];
 extern const char HAExpireAfterProperty[];
+extern const char HAEnabledByDefaultProperty[];
+extern const char HASupportedFeaturesProperty[];
+extern const char HACodeArmRequiredProperty[];
+extern const char HACodeDisarmRequiredProperty[];
+extern const char HACodeTriggerRequiredProperty[];
+extern const char HACodeProperty[];
 
 // topics
 extern const char HAConfigTopic[];
@@ -105,6 +112,14 @@ extern const char HATemperatureStateTopic[];
 extern const char HARGBCommandTopic[];
 extern const char HARGBStateTopic[];
 extern const char HAJsonAttributesTopic[];
+extern const char HAPayloadArmAwayTopic[];
+extern const char HAPayloadArmCustomBypassTopic[];
+extern const char HAPayloadArmHomeTopic[];
+extern const char HAPayloadArmNightTopic[];
+extern const char HAPayloadArmVacationTopic[];
+extern const char HAPayloadDisarmTopic[];
+extern const char HAPayloadTriggerTopic[];
+
 
 // misc
 extern const char HAOnline[];
@@ -121,6 +136,22 @@ extern const char HANotHome[];
 extern const char HATrigger[];
 extern const char HAModeBox[];
 extern const char HAModeSlider[];
+extern const char HAEntityCategory[];
+extern const char HAArmHome[];
+extern const char HAArmAway[];
+extern const char HAArmNight[];
+extern const char HAArmVacation[];
+extern const char HAArmCustomBypass[];
+extern const char HAStateArmedAway[];
+extern const char HAStateArmedCustomBypass[];
+extern const char HAStateArmedHome[];
+extern const char HAStateArmedNight[];
+extern const char HAStateArmedVacation[];
+extern const char HAStateArming[];
+extern const char HAStateDisarmed[];
+extern const char HAStateDisarming[];
+extern const char HAStatePending[];
+extern const char HAStateTriggered[];
 
 // covers
 extern const char HAClosedState[];


### PR DESCRIPTION
This change adds core support for the alarm_control_panel entity, including arm/disarm code validation, and a corresponding example ino. 

This change also adds the enable_by_default and entity_category properties to the most common entities (sensor, number, binary_sensory, button, select). This is useful for adding configuration and control entities that are correctly categorized and exposed in the device UI in HA, as well as enabling you to hide them by default (if, for example, most people wouldn't need access to them but can enable access themselves after discovery.)