### PR TITLE
Add support for std::function on the ESP devices

### DIFF
--- a/src/device-types/HAButton.h
+++ b/src/device-types/HAButton.h
@@ -5,7 +5,12 @@
 
 #ifndef EX_ARDUINOHA_BUTTON
 
+#if defined(ESP32) || defined(ESP8266)
+#define HABUTTON_CALLBACK(name) std::function<void(HAButton* sender)> name
+#else
 #define HABUTTON_CALLBACK(name) void (*name)(HAButton* sender)
+#endif
+
 
 /**
  * HAButton represents a button that's displayed in the Home Assistant panel and

--- a/src/device-types/HAButton.h
+++ b/src/device-types/HAButton.h
@@ -6,11 +6,12 @@
 #ifndef EX_ARDUINOHA_BUTTON
 
 #if defined(ESP32) || defined(ESP8266)
-#define HABUTTON_CALLBACK(name) std::function<void(HAButton* sender)> name
+#include <functional>
+#define HABUTTON_CALLBACK_STD(name) std::function<void(HAButton* sender)> name
+#define HABUTTON_CALLBACK_PTR(name) void (*name)(HAButton* sender)
 #else
-#define HABUTTON_CALLBACK(name) void (*name)(HAButton* sender)
+#define HABUTTON_CALLBACK_PTR(name) void (*name)(HAButton* sender)
 #endif
-
 
 /**
  * HAButton represents a button that's displayed in the Home Assistant panel and
@@ -55,14 +56,40 @@ public:
     inline void setRetain(const bool retain)
         { _retain = retain; }
 
+#if defined(ESP32) || defined(ESP8266)
     /**
-     * Registers callback that will be called each time the press command from HA is received.
-     * Please note that it's not possible to register multiple callbacks for the same button.
+     * Registers a callback that will be called each time the press command from HA is received.
+     * This overload accepts a pointer to a function.
      *
-     * @param callback
+     * @param callback Pointer to a function.
      */
-    inline void onCommand(HABUTTON_CALLBACK(callback))
+    void onCommand(HABUTTON_CALLBACK_PTR(callback)) {
+        _commandCallback = [callback](HAButton* sender) {
+            if (callback) {
+                callback(sender);
+            }
+        };
+    }
+
+    /**
+     * Registers a callback that will be called each time the press command from HA is received.
+     * This overload accepts a std::function.
+     *
+     * @param callback std::function.
+     */
+    void onCommand(HABUTTON_CALLBACK_STD(callback)) {
+        _commandCallback = std::move(callback);
+    }
+#else
+    /**
+     * Registers a callback that will be called each time the press command from HA is received.
+     * This version is used for platforms without std::function support.
+     *
+     * @param callback Pointer to a function.
+     */
+    inline void onCommand(HABUTTON_CALLBACK_PTR(callback))
         { _commandCallback = callback; }
+#endif
 
 protected:
     virtual void buildSerializer() override;
@@ -84,7 +111,11 @@ private:
     bool _retain;
 
     /// The command callback that will be called once clicking the button in HA panel.
-    HABUTTON_CALLBACK(_commandCallback);
+#if defined(ESP32) || defined(ESP8266)
+    HABUTTON_CALLBACK_STD(_commandCallback);
+#else
+    HABUTTON_CALLBACK_PTR(_commandCallback);
+#endif
 };
 
 #endif

--- a/src/device-types/HACover.h
+++ b/src/device-types/HACover.h
@@ -5,7 +5,11 @@
 
 #ifndef EX_ARDUINOHA_COVER
 
+#if defined(ESP32) || defined(ESP8266)
+#define HACOVER_CALLBACK(name) std::function<void(CoverCommand cmd, HACover* sender)> name
+#else
 #define HACOVER_CALLBACK(name) void (*name)(CoverCommand cmd, HACover* sender)
+#endif
 
 /**
  * HACover allows to control a cover (such as blinds, a roller shutter or a garage door).

--- a/src/device-types/HAFan.h
+++ b/src/device-types/HAFan.h
@@ -6,8 +6,17 @@
 
 #ifndef EX_ARDUINOHA_FAN
 
+#if defined(ESP32) || defined(ESP8266)
+#define HAFAN_STATE_CALLBACK(name) std::function<void(bool state, HAFan* sender)> name
+#else
 #define HAFAN_STATE_CALLBACK(name) void (*name)(bool state, HAFan* sender)
+#endif
+
+#if defined(ESP32) || defined(ESP8266)
+#define HAFAN_SPEED_CALLBACK(name) std::function<void(uint16_t speed, HAFan* sender)> name
+#else
 #define HAFAN_SPEED_CALLBACK(name) void (*name)(uint16_t speed, HAFan* sender)
+#endif
 
 /**
  * HAFan allows adding a controllable fan in the Home Assistant panel.

--- a/src/device-types/HAFan.h
+++ b/src/device-types/HAFan.h
@@ -7,15 +7,14 @@
 #ifndef EX_ARDUINOHA_FAN
 
 #if defined(ESP32) || defined(ESP8266)
-#define HAFAN_STATE_CALLBACK(name) std::function<void(bool state, HAFan* sender)> name
+#include <functional>
+#define HAFAN_STATE_CALLBACK_STD(name) std::function<void(bool state, HAFan* sender)> name
+#define HAFAN_STATE_CALLBACK_PTR(name) void (*name)(bool state, HAFan* sender)
+#define HAFAN_SPEED_CALLBACK_STD(name) std::function<void(uint16_t speed, HAFan* sender)> name
+#define HAFAN_SPEED_CALLBACK_PTR(name) void (*name)(uint16_t speed, HAFan* sender)
 #else
-#define HAFAN_STATE_CALLBACK(name) void (*name)(bool state, HAFan* sender)
-#endif
-
-#if defined(ESP32) || defined(ESP8266)
-#define HAFAN_SPEED_CALLBACK(name) std::function<void(uint16_t speed, HAFan* sender)> name
-#else
-#define HAFAN_SPEED_CALLBACK(name) void (*name)(uint16_t speed, HAFan* sender)
+#define HAFAN_STATE_CALLBACK_PTR(name) void (*name)(bool state, HAFan* sender)
+#define HAFAN_SPEED_CALLBACK_PTR(name) void (*name)(uint16_t speed, HAFan* sender)
 #endif
 
 /**
@@ -157,6 +156,61 @@ public:
     inline void setSpeedRangeMin(const uint16_t min)
         { _speedRangeMin.setBaseValue(min); }
 
+#if defined(ESP32) || defined(ESP8266)
+    /**
+     * Registers callback that will be called each time the state command from HA is received.
+     * Please note that it's not possible to register multiple callbacks for the same fan.
+     * This overload accepts a pointer to a function.
+     *
+     * @param callback
+     * @note In non-optimistic mode, the state must be reported back to HA using the HAFan::setState method.
+     */
+    inline void onStateCommand(HAFAN_STATE_CALLBACK_PTR(callback)) {
+        _stateCallback = [callback](bool state, HAFan* sender) {
+            if (callback) {
+                callback(state, sender);
+            }
+        };
+    }
+
+    /**
+     * Registers callback that will be called each time the speed command from HA is received.
+     * Please note that it's not possible to register multiple callbacks for the same fan.
+     * This overload accepts a pointer to a function.
+     *
+     * @param callback
+     * @note In non-optimistic mode, the speed must be reported back to HA using the HAFan::setSpeed method.
+     */
+    inline void onSpeedCommand(HAFAN_SPEED_CALLBACK_PTR(callback)) {
+        _speedCallback = [callback](uint16_t speed, HAFan* sender) {
+            if (callback) {
+                callback(speed, sender);
+            }
+        };
+    }
+
+    /**
+     * Registers callback that will be called each time the state command from HA is received.
+     * Please note that it's not possible to register multiple callbacks for the same fan.
+     * This overload accepts a std::function.
+     *
+     * @param callback
+     * @note In non-optimistic mode, the state must be reported back to HA using the HAFan::setState method.
+     */
+    inline void onStateCommand(HAFAN_STATE_CALLBACK_STD(callback))
+        { _stateCallback = std::move(callback); }
+
+    /**
+     * Registers callback that will be called each time the speed command from HA is received.
+     * Please note that it's not possible to register multiple callbacks for the same fan.
+     * This overload accepts a std::function.
+     *
+     * @param callback
+     * @note In non-optimistic mode, the speed must be reported back to HA using the HAFan::setSpeed method.
+     */
+    inline void onSpeedCommand(HAFAN_SPEED_CALLBACK_STD(callback))
+        { _speedCallback = std::move(callback); }
+#else
     /**
      * Registers callback that will be called each time the state command from HA is received.
      * Please note that it's not possible to register multiple callbacks for the same fan.
@@ -164,7 +218,7 @@ public:
      * @param callback
      * @note In non-optimistic mode, the state must be reported back to HA using the HAFan::setState method.
      */
-    inline void onStateCommand(HAFAN_STATE_CALLBACK(callback))
+    inline void onStateCommand(HAFAN_STATE_CALLBACK_PTR(callback))
         { _stateCallback = callback; }
 
     /**
@@ -174,8 +228,9 @@ public:
      * @param callback
      * @note In non-optimistic mode, the speed must be reported back to HA using the HAFan::setSpeed method.
      */
-    inline void onSpeedCommand(HAFAN_SPEED_CALLBACK(callback))
+    inline void onSpeedCommand(HAFAN_SPEED_CALLBACK_PTR(callback))
         { _speedCallback = callback; }
+#endif
 
 protected:
     virtual void buildSerializer() override;
@@ -244,10 +299,18 @@ private:
     uint16_t _currentSpeed;
 
     /// The callback that will be called when the state command is received from the HA.
-    HAFAN_STATE_CALLBACK(_stateCallback);
+#if defined(ESP32) || defined(ESP8266)
+    HAFAN_STATE_CALLBACK_STD(_stateCallback);
+#else
+    HAFAN_STATE_CALLBACK_PTR(_stateCallback);
+#endif
 
     /// The callback that will be called when the speed command is received from the HA.
-    HAFAN_SPEED_CALLBACK(_speedCallback);
+#if defined(ESP32) || defined(ESP8266)
+    HAFAN_SPEED_CALLBACK_STD(_speedCallback);
+#else
+    HAFAN_SPEED_CALLBACK_PTR(_speedCallback);
+#endif
 };
 
 #endif

--- a/src/device-types/HAHVAC.h
+++ b/src/device-types/HAHVAC.h
@@ -26,11 +26,35 @@
     inline void setCurrentTargetTemperature(const type temperature) \
         { setCurrentTargetTemperature(HANumeric(temperature, _precision)); }
 
+#if defined(ESP32) || defined(ESP8266)
+#define HAHVAC_CALLBACK_BOOL(name) std::function<void(bool state, HAHVAC* sender)> name
+#else
 #define HAHVAC_CALLBACK_BOOL(name) void (*name)(bool state, HAHVAC* sender)
+#endif
+
+#if defined(ESP32) || defined(ESP8266)
+#define HAHVAC_CALLBACK_TARGET_TEMP(name) std::function<void(HANumeric temperature, HAHVAC* sender)> name
+#else
 #define HAHVAC_CALLBACK_TARGET_TEMP(name) void (*name)(HANumeric temperature, HAHVAC* sender)
+#endif
+
+#if defined(ESP32) || defined(ESP8266)
+#define HAHVAC_CALLBACK_FAN_MODE(name) std::function<void(FanMode mode, HAHVAC* sender)> name
+#else
 #define HAHVAC_CALLBACK_FAN_MODE(name) void (*name)(FanMode mode, HAHVAC* sender)
+#endif
+
+#if defined(ESP32) || defined(ESP8266)
+#define HAHVAC_CALLBACK_SWING_MODE(name) std::function<void(SwingMode mode, HAHVAC* sender)> name
+#else
 #define HAHVAC_CALLBACK_SWING_MODE(name) void (*name)(SwingMode mode, HAHVAC* sender)
+#endif
+
+#if defined(ESP32) || defined(ESP8266)
+#define HAHVAC_CALLBACK_MODE(name) std::function<void(Mode mode, HAHVAC* sender)> name
+#else
 #define HAHVAC_CALLBACK_MODE(name) void (*name)(Mode mode, HAHVAC* sender)
+#endif
 
 class HASerializerArray;
 

--- a/src/device-types/HALight.h
+++ b/src/device-types/HALight.h
@@ -6,10 +6,29 @@
 
 #ifndef EX_ARDUINOHA_LIGHT
 
+#if defined(ESP32) || defined(ESP8266)
+#define HALIGHT_STATE_CALLBACK(name) std::function<void(bool state, HALight* sender)> name
+#else
 #define HALIGHT_STATE_CALLBACK(name) void (*name)(bool state, HALight* sender)
+#endif
+
+#if defined(ESP32) || defined(ESP8266)
+#define HALIGHT_BRIGHTNESS_CALLBACK(name) std::function<void(uint8_t brightness, HALight* sender)> name
+#else
 #define HALIGHT_BRIGHTNESS_CALLBACK(name) void (*name)(uint8_t brightness, HALight* sender)
+#endif
+
+#if defined(ESP32) || defined(ESP8266)
+#define HALIGHT_COLOR_TEMP_CALLBACK(name) std::function<void(uint16_t temperature, HALight* sender)> name
+#else
 #define HALIGHT_COLOR_TEMP_CALLBACK(name) void (*name)(uint16_t temperature, HALight* sender)
+#endif
+
+#if defined(ESP32) || defined(ESP8266)
+#define HALIGHT_RGB_COLOR_CALLBACK(name) std::function<void(HALight::RGBColor color, HALight* sender)> name
+#else
 #define HALIGHT_RGB_COLOR_CALLBACK(name) void (*name)(HALight::RGBColor color, HALight* sender)
+#endif
 
 /**
  * HALight allows adding a controllable light in the Home Assistant panel.

--- a/src/device-types/HALock.h
+++ b/src/device-types/HALock.h
@@ -5,7 +5,11 @@
 
 #ifndef EX_ARDUINOHA_LOCK
 
+#if defined(ESP32) || defined(ESP8266)
+#define HALOCK_CALLBACK(name) std::function<void(LockCommand command, HALock* sender)> name
+#else
 #define HALOCK_CALLBACK(name) void (*name)(LockCommand command, HALock* sender)
+#endif
 
 /**
  * HALock allows to implement a custom lock (for example: door lock)

--- a/src/device-types/HALock.h
+++ b/src/device-types/HALock.h
@@ -6,9 +6,10 @@
 #ifndef EX_ARDUINOHA_LOCK
 
 #if defined(ESP32) || defined(ESP8266)
-#define HALOCK_CALLBACK(name) std::function<void(LockCommand command, HALock* sender)> name
+#define HALOCK_CALLBACK_STD(name) std::function<void(LockCommand command, HALock* sender)> name
+#define HALOCK_CALLBACK_PTR(name) void (*name)(LockCommand command, HALock* sender)
 #else
-#define HALOCK_CALLBACK(name) void (*name)(LockCommand command, HALock* sender)
+#define HALOCK_CALLBACK_PTR(name) void (*name)(LockCommand command, HALock* sender)
 #endif
 
 /**
@@ -97,14 +98,42 @@ public:
     inline void setOptimistic(const bool optimistic)
         { _optimistic = optimistic; }
 
+#if defined(ESP32) || defined(ESP8266)
     /**
      * Registers callback that will be called each time the lock/unlock/open command from the HA is received.
      * Please note that it's not possible to register multiple callbacks for the same lock.
+     * This overload accepts a pointer to a function.
      *
      * @param callback
      */
-    inline void onCommand(HALOCK_CALLBACK(callback))
+    inline void onCommand(HALOCK_CALLBACK_PTR(callback)) {
+      _commandCallback = [callback](LockCommand command, HALock* sender) {
+            if (callback) {
+                callback(command, sender);
+            }
+        };
+    }
+
+    /**
+     * Registers callback that will be called each time the lock/unlock/open command from the HA is received.
+     * Please note that it's not possible to register multiple callbacks for the same lock.
+     * This overload accepts a std::function.
+     *
+     * @param callback
+     */
+    inline void onCommand(HALOCK_CALLBACK_STD(callback))
+        { _commandCallback = std::move(callback); }
+#else
+    /**
+     * Registers callback that will be called each time the lock/unlock/open command from the HA is received.
+     * Please note that it's not possible to register multiple callbacks for the same lock.
+     * This version is used for platforms without std::function support.
+     *
+     * @param callback
+     */
+    inline void onCommand(HALOCK_CALLBACK_PTR(callback))
         { _commandCallback = callback; }
+#endif
 
 protected:
     virtual void buildSerializer() override;
@@ -145,7 +174,11 @@ private:
     LockState _currentState;
 
     /// The callback that will be called when lock/unlock/open command is received from the HA.
-    HALOCK_CALLBACK(_commandCallback);
+#if defined(ESP32) || defined(ESP8266)
+    HALOCK_CALLBACK_STD(_commandCallback);
+#else
+    HALOCK_CALLBACK_PTR(_commandCallback);
+#endif
 };
 
 #endif

--- a/src/device-types/HANumber.h
+++ b/src/device-types/HANumber.h
@@ -17,9 +17,10 @@
         { setCurrentState(HANumeric(state, _precision)); }
 
 #if defined(ESP32) || defined(ESP8266)
-#define HANUMBER_CALLBACK(name) std::function<void(HANumeric number, HANumber* sender)> name
+#define HANUMBER_CALLBACK_STD(name) std::function<void(HANumeric number, HANumber* sender)> name
+#define HANUMBER_CALLBACK_PTR(name) void (*name)(HANumeric number, HANumber* sender)
 #else
-#define HANUMBER_CALLBACK(name) void (*name)(HANumeric number, HANumber* sender)
+#define HANUMBER_CALLBACK_PTR(name) void (*name)(HANumeric number, HANumber* sender)
 #endif
 
 /**
@@ -180,15 +181,45 @@ public:
     inline void setStep(const float step)
         { _step = HANumeric(step, _precision); }
 
+#if defined(ESP32) || defined(ESP8266)
     /**
      * Registers callback that will be called each time the number is changed in the HA panel.
      * Please note that it's not possible to register multiple callbacks for the same number.
+     * This overload accepts a pointer to a function.
      *
      * @param callback
      * @note In non-optimistic mode, the number must be reported back to HA using the HANumber::setState method.
      */
-    inline void onCommand(HANUMBER_CALLBACK(callback))
+    inline void onCommand(HANUMBER_CALLBACK_PTR(callback)) {
+      _commandCallback = [callback](HANumeric number, HANumber* sender) {
+            if (callback) {
+                callback(number, sender);
+            }
+        };
+    }
+
+    /**
+     * Registers callback that will be called each time the number is changed in the HA panel.
+     * Please note that it's not possible to register multiple callbacks for the same number.
+     * This overload accepts a std::function.
+     *
+     * @param callback
+     * @note In non-optimistic mode, the number must be reported back to HA using the HANumber::setState method.
+     */
+    inline void onCommand(HANUMBER_CALLBACK_STD(callback))
+        { _commandCallback = std::move(callback); }
+#else
+    /**
+     * Registers callback that will be called each time the number is changed in the HA panel.
+     * Please note that it's not possible to register multiple callbacks for the same number.
+     * This version is used for platforms without std::function support.
+     *
+     * @param callback
+     * @note In non-optimistic mode, the number must be reported back to HA using the HANumber::setState method.
+     */
+    inline void onCommand(HANUMBER_CALLBACK_PTR(callback))
         { _commandCallback = callback; }
+#endif
 
 protected:
     virtual void buildSerializer() override;
@@ -260,7 +291,11 @@ private:
     HANumeric _currentState;
 
     /// The callback that will be called when the command is received from the HA.
-    HANUMBER_CALLBACK(_commandCallback);
+#if defined(ESP32) || defined(ESP8266)
+    HANUMBER_CALLBACK_STD(_commandCallback);
+#else
+    HANUMBER_CALLBACK_PTR(_commandCallback);
+#endif
 };
 
 #endif

--- a/src/device-types/HANumber.h
+++ b/src/device-types/HANumber.h
@@ -16,7 +16,11 @@
     inline void setCurrentState(const type state) \
         { setCurrentState(HANumeric(state, _precision)); }
 
+#if defined(ESP32) || defined(ESP8266)
+#define HANUMBER_CALLBACK(name) std::function<void(HANumeric number, HANumber* sender)> name
+#else
 #define HANUMBER_CALLBACK(name) void (*name)(HANumeric number, HANumber* sender)
+#endif
 
 /**
  * HANumber adds a slider or a box in the Home Assistant panel

--- a/src/device-types/HAScene.h
+++ b/src/device-types/HAScene.h
@@ -5,7 +5,11 @@
 
 #ifndef EX_ARDUINOHA_SCENE
 
+#if defined(ESP32) || defined(ESP8266)
+#define HASCENE_CALLBACK(name) std::function<void(HAScene* sender)> name
+#else
 #define HASCENE_CALLBACK(name) void (*name)(HAScene* sender)
+#endif
 
 /**
  * HAScene adds a new scene to the Home Assistant that triggers your callback once activated.

--- a/src/device-types/HASelect.h
+++ b/src/device-types/HASelect.h
@@ -7,7 +7,11 @@
 
 class HASerializerArray;
 
+#if defined(ESP32) || defined(ESP8266)
+#define HASELECT_CALLBACK(name) std::function<void(int8_t index, HASelect* sender)> name
+#else
 #define HASELECT_CALLBACK(name) void (*name)(int8_t index, HASelect* sender)
+#endif
 
 /**
  * HASelect adds a dropdown with options in the Home Assistant panel.

--- a/src/device-types/HASelect.h
+++ b/src/device-types/HASelect.h
@@ -8,9 +8,10 @@
 class HASerializerArray;
 
 #if defined(ESP32) || defined(ESP8266)
-#define HASELECT_CALLBACK(name) std::function<void(int8_t index, HASelect* sender)> name
+#define HASELECT_CALLBACK_STD(name) std::function<void(int8_t index, HASelect* sender)> name
+#define HASELECT_CALLBACK_PTR(name) void (*name)(int8_t index, HASelect* sender)
 #else
-#define HASELECT_CALLBACK(name) void (*name)(int8_t index, HASelect* sender)
+#define HASELECT_CALLBACK_PTR(name) void (*name)(int8_t index, HASelect* sender)
 #endif
 
 /**
@@ -105,15 +106,45 @@ public:
     inline void setOptimistic(const bool optimistic)
         { _optimistic = optimistic; }
 
+#if defined(ESP32) || defined(ESP8266)
     /**
      * Registers callback that will be called each time the option is changed from the HA panel.
      * Please note that it's not possible to register multiple callbacks for the same select.
+     * This overload accepts a pointer to a function.
      *
      * @param callback
      * @note In non-optimistic mode, the selected option must be reported back to HA using the HASelect::setState method.
      */
-    inline void onCommand(HASELECT_CALLBACK(callback))
+    inline void onCommand(HASELECT_CALLBACK_PTR(callback)) {
+      _commandCallback = [callback](int8_t index, HASelect* sender) {
+            if (callback) {
+                callback(index, sender);
+            }
+        };
+    }
+
+    /**
+     * Registers callback that will be called each time the option is changed from the HA panel.
+     * Please note that it's not possible to register multiple callbacks for the same select.
+     * This overload accepts a std::function.
+     *
+     * @param callback
+     * @note In non-optimistic mode, the selected option must be reported back to HA using the HASelect::setState method.
+     */
+    inline void onCommand(HASELECT_CALLBACK_STD(callback))
+        { _commandCallback = std::move(callback); }
+#else
+    /**
+     * Registers callback that will be called each time the option is changed from the HA panel.
+     * Please note that it's not possible to register multiple callbacks for the same select.
+     * This version is used for platforms without std::function support.
+     *
+     * @param callback
+     * @note In non-optimistic mode, the selected option must be reported back to HA using the HASelect::setState method.
+     */
+    inline void onCommand(HASELECT_CALLBACK_PTR(callback))
         { _commandCallback = callback; }
+#endif
 
 #ifdef ARDUINOHA_TEST
     inline HASerializerArray* getOptions() const
@@ -159,7 +190,11 @@ private:
     bool _optimistic;
 
     /// The command callback that will be called when option is changed via the HA panel.
-    HASELECT_CALLBACK(_commandCallback);
+#if defined(ESP32) || defined(ESP8266)
+    HASELECT_CALLBACK_STD(_commandCallback);
+#else
+    HASELECT_CALLBACK_PTR(_commandCallback);
+#endif
 };
 
 #endif

--- a/src/device-types/HASwitch.h
+++ b/src/device-types/HASwitch.h
@@ -5,7 +5,13 @@
 
 #ifndef EX_ARDUINOHA_SWITCH
 
+
+#if defined(ESP32) || defined(ESP8266)
+#define HASWITCH_CALLBACK(name) std::function<void(bool state, HASwitch* sender)> name
+#else
 #define HASWITCH_CALLBACK(name) void (*name)(bool state, HASwitch* sender)
+#endif
+
 
 /**
  * HASwitch allows to display on/off switch in the HA panel and receive commands on your device.

--- a/src/device-types/HASwitch.h
+++ b/src/device-types/HASwitch.h
@@ -7,9 +7,10 @@
 
 
 #if defined(ESP32) || defined(ESP8266)
-#define HASWITCH_CALLBACK(name) std::function<void(bool state, HASwitch* sender)> name
+#define HASWITCH_CALLBACK_STD(name) std::function<void(bool state, HASwitch* sender)> name
+#define HASWITCH_CALLBACK_PTR(name) void (*name)(bool state, HASwitch* sender)
 #else
-#define HASWITCH_CALLBACK(name) void (*name)(bool state, HASwitch* sender)
+#define HASWITCH_CALLBACK_PTR(name) void (*name)(bool state, HASwitch* sender)
 #endif
 
 
@@ -105,15 +106,45 @@ public:
     inline void setOptimistic(const bool optimistic)
         { _optimistic = optimistic; }
 
+#if defined(ESP32) || defined(ESP8266)
     /**
      * Registers callback that will be called each time the on/off command from HA is received.
      * Please note that it's not possible to register multiple callbacks for the same switch.
+     * This overload accepts a pointer to a function.
      *
      * @param callback
      * @note In non-optimistic mode, the state must be reported back to HA using the HASwitch::setState method.
      */
-    inline void onCommand(HASWITCH_CALLBACK(callback))
+    inline void onCommand(HASWITCH_CALLBACK_PTR(callback)) {
+      _commandCallback = [callback](bool state, HASwitch* sender) {
+            if (callback) {
+                callback(state, sender);
+            }
+        };
+    }
+
+    /**
+     * Registers callback that will be called each time the on/off command from HA is received.
+     * Please note that it's not possible to register multiple callbacks for the same switch.
+     * This overload accepts a std::function.
+     *
+     * @param callback
+     * @note In non-optimistic mode, the state must be reported back to HA using the HASwitch::setState method.
+     */
+    inline void onCommand(HASWITCH_CALLBACK_STD(callback))
+        { _commandCallback = std::move(callback); }
+#else
+    /**
+     * Registers callback that will be called each time the on/off command from HA is received.
+     * Please note that it's not possible to register multiple callbacks for the same switch.
+     * This version is used for platforms without std::function support.
+     *
+     * @param callback
+     * @note In non-optimistic mode, the state must be reported back to HA using the HASwitch::setState method.
+     */
+    inline void onCommand(HASWITCH_CALLBACK_PTR(callback))
         { _commandCallback = callback; }
+#endif
 
 protected:
     virtual void buildSerializer() override;
@@ -149,7 +180,11 @@ private:
     bool _currentState;
 
     /// The callback that will be called when switch command is received from the HA.
-    HASWITCH_CALLBACK(_commandCallback);
+#if defined(ESP32) || defined(ESP8266)
+    HASWITCH_CALLBACK_STD(_commandCallback);
+#else
+    HASWITCH_CALLBACK_PTR(_commandCallback);
+#endif
 };
 
 #endif


### PR DESCRIPTION
Hi! Merry Christmas and Happy New Year!

This PR adds conditional compilation flow for ESP32/ESP8266 platforms to allow using the `std::function` as a command callback.

I hope I've found all the places. But if it's not true — please point me and I'll update the missing places.

This closes #143.