### PR TITLE
Add support for "Valve" device type

### DIFF
--- a/examples/valve/valve-basic.ino
+++ b/examples/valve/valve-basic.ino
@@ -1,0 +1,72 @@
+#include <Ethernet.h>
+#include <ArduinoHA.h>
+
+#define BROKER_ADDR     IPAddress(192,168,0,17)
+
+byte mac[] = {0x00, 0x10, 0xFA, 0x6E, 0x38, 0x4A};
+
+EthernetClient client;
+HADevice device(mac, sizeof(mac));
+HAMqtt mqtt(client, device);
+
+// "myValve" is unique ID of the valve. You should define your own ID.
+HAValve valve("myValve");
+
+// HA will not send state stopped unless device advertises feature compatibility
+// HAValve valve("myValve", HAValve::StopFeature);
+
+// For basic operation, HA will send named states to the state topic
+// See https://www.home-assistant.io/integrations/valve.mqtt/
+
+void onValveCommand(int16_t cmd, HAValve* sender) {
+    if (cmd == HAValve::CommandOpen) {
+        Serial.println("Command: Open");
+        sender->setState(HAValve::StateOpening); // report state back to the HA
+    } else if (cmd == HAValve::CommandClose) {
+        Serial.println("Command: Close");
+        sender->setState(HAValve::StateClosing); // report state back to the HA
+    } else if (cmd == HAValve::CommandStop) {
+        Serial.println("Command: Stop");
+        sender->setState(HAValve::StateClosed); // valve cannot report state stopped!
+    }
+
+    // Available states:
+    // HAValve::StateClosed
+    // HAValve::StateClosing
+    // HAValve::StateOpen
+    // HAValve::StateOpening
+}
+
+void setup() {
+    Serial.begin(9600);
+    Ethernet.begin(mac);
+
+    // optional device's details
+    device.setName("Arduino");
+    device.setSoftwareVersion("1.0.0");
+
+    valve.onCommand(onValveCommand);
+    valve.setName("My valve"); // optional
+
+    // Optionally you can set the device class
+    // see https://www.home-assistant.io/integrations/valve/#device-class
+    // valve.setDeviceClass("water");
+    
+    // Optionally you can set retain flag for the HA commands
+    // valve.setRetain(true);
+
+    // Optionally you can enable optimistic mode for the HAValve.
+    // In this mode you won't need to report state back to the HA when commands are executed.
+    // valve.setOptimistic(true);
+
+    mqtt.begin(BROKER_ADDR);
+}
+
+void loop() {
+    Ethernet.maintain();
+    mqtt.loop();
+
+    // You can also change the state at runtime as shown below.
+    // This kind of logic can be used if you want to control your valve using a button connected to the device.
+    // valve.setState(HAValve::StateOpening); // use any state you want
+}

--- a/examples/valve/valve-with-position.ino
+++ b/examples/valve/valve-with-position.ino
@@ -1,0 +1,79 @@
+#include <Ethernet.h>
+#include <ArduinoHA.h>
+
+#define BROKER_ADDR     IPAddress(192,168,0,17)
+
+byte mac[] = {0x00, 0x10, 0xFA, 0x6E, 0x38, 0x4A};
+
+EthernetClient client;
+HADevice device(mac, sizeof(mac));
+HAMqtt mqtt(client, device);
+
+// "myValve" is unique ID of the valve. You should define your own ID.
+HAValve valve("myValve", HAValve::PositionFeature);
+
+// When using PositionFeature is optional, HA will only send a numeric state
+// The value is between "positionOpen" and "positionClosed"
+// See https://www.home-assistant.io/integrations/valve.mqtt/
+
+void onValveCommand(int16_t cmd, HAValve* sender) {
+    if (cmd == valve.getPositionOpen()) {
+        Serial.println("Command: Open");
+        sender->setState(HAValve::StateOpening); // report state back to the HA
+    } else if (cmd == valve.getPositionClosed()) {
+        Serial.println("Command: Close");
+        sender->setState(HAValve::StateClosing); // report state back to the HA
+    } else {
+        Serial.print("Position: "); Serial.println(cmd);
+        sender->setPosition(cmd); // report position back to the HA
+    }
+
+    // Available states:
+    // HAValve::StateClosed
+    // HAValve::StateClosing
+    // HAValve::StateOpen
+    // HAValve::StateOpening
+
+    // You can also report position using setPosition() method
+    // However, for the position feature, HA supports sending both in one message
+    // It may advisable to use this method instead
+    // sender->setStateWithPosition(HAValve::StateOpening, 42);
+}
+
+void setup() {
+    Serial.begin(9600);
+    Ethernet.begin(mac);
+
+    // optional device's details
+    device.setName("Arduino");
+    device.setSoftwareVersion("1.0.0");
+
+    valve.onCommand(onValveCommand);
+    valve.setName("My valve"); // optional
+
+    // Optionally you can set the device class
+    // see https://www.home-assistant.io/integrations/valve/#device-class
+    // valve.setDeviceClass("water");
+    
+    // Optionally define the open/closed values (default 0-100)
+    // valve.setPositionClosed(16);
+    // valve.setPositionOpen(1024);
+    
+    // Optionally you can set retain flag for the HA commands
+    // valve.setRetain(true);
+
+    // Optionally you can enable optimistic mode for the HAValve.
+    // In this mode you won't need to report state back to the HA when commands are executed.
+    // valve.setOptimistic(true);
+
+    mqtt.begin(BROKER_ADDR);
+}
+
+void loop() {
+    Ethernet.maintain();
+    mqtt.loop();
+
+    // You can also change the state at runtime as shown below.
+    // This kind of logic can be used if you want to control your valve using a button connected to the device.
+    // valve.setState(HAValve::StateOpening); // use any state you want
+}

--- a/src/ArduinoHA.h
+++ b/src/ArduinoHA.h
@@ -20,6 +20,7 @@
 #include "device-types/HASensorNumber.h"
 #include "device-types/HASwitch.h"
 #include "device-types/HATagScanner.h"
+#include "device-types/HAValve.h"
 #include "utils/HAUtils.h"
 #include "utils/HANumeric.h"
 

--- a/src/ArduinoHADefines.h
+++ b/src/ArduinoHADefines.h
@@ -20,6 +20,7 @@
 // #define EX_ARDUINOHA_SENSOR
 // #define EX_ARDUINOHA_SWITCH
 // #define EX_ARDUINOHA_TAG_SCANNER
+// #define EX_ARDUINOHA_VALVE
 
 #if defined(ARDUINOHA_DEBUG)
     #include <Arduino.h>

--- a/src/device-types/HAValve.cpp
+++ b/src/device-types/HAValve.cpp
@@ -176,7 +176,6 @@ bool HAValve::publishState(StatePublishType type, ValveState state, int16_t posi
 {
   const __FlashStringHelper *stateStr = nullptr;
   char positionStr[6 + 1] = {0}; // int16_t digits with null terminator
-  HANumeric positionNum = HANumeric(position, 0);
   
   // for state only or combo
   if (type == StatePublishString  ||  type == StatePublishJson) {
@@ -228,8 +227,9 @@ bool HAValve::publishState(StatePublishType type, ValveState state, int16_t posi
   
   if (type == StatePublishJson) {
     char jsonState[40];
-    sprintf(
+    snprintf(
       jsonState,
+      40,
       "{\"%s\":\"%s\",\"%s\":%d}",
       AHAFROMFSTR(HAStateProperty),
       AHAFROMFSTR(stateStr),

--- a/src/device-types/HAValve.cpp
+++ b/src/device-types/HAValve.cpp
@@ -1,0 +1,266 @@
+#include "HAValve.h"
+#ifndef EX_ARDUINOHA_VALVE
+
+#include "../HAMqtt.h"
+#include "../utils/HAUtils.h"
+#include "../utils/HANumeric.h"
+#include "../utils/HASerializer.h"
+
+HAValve::HAValve(const char* uniqueId, const uint16_t features) :
+    HABaseDeviceType(AHATOFSTR(HAComponentValve), uniqueId),
+    _features(features),
+    _currentState(StateUnknown),
+    _currentPosition(DefaultPosition),
+    _positionOpen(HANumeric((uint16_t)100, 0)),
+    _positionClosed(HANumeric((uint16_t)0, 0)),
+    _class(nullptr),
+    _icon(nullptr),
+    _retain(false),
+    _optimistic(false),
+    _commandCallback(nullptr)
+{
+}
+
+bool HAValve::setState(const ValveState state, const bool force)
+{
+    if (!force && _currentState == state) {
+        return true;
+    }
+    
+    if (_features & PositionFeature) {
+      // if position enabled, state topic wants position
+      if (publishState(StatePublishJson, state, _currentPosition)) {
+          _currentState = state;
+          return true;
+      }
+    } else {
+      // normal is standard state strings
+      if (publishState(StatePublishString, state, -1)) {
+          _currentState = state;
+          return true;
+      }
+    }
+
+    return false;
+}
+
+bool HAValve::setPosition(const int16_t position, const bool force)
+{
+    if (!force && _currentPosition == position) {
+        return true;
+    }
+
+    if (publishState(StatePublishNumeric, StateUnknown, position)) {
+        _currentPosition = position;
+        return true;
+    }
+
+    return false;
+}
+
+bool HAValve::setStateWithPosition(const ValveState state, const int16_t position, const bool force) {
+  if (!force && _currentState == state && _currentPosition == position) {
+      return true;
+  }
+
+  if (publishState(StatePublishJson, state, position)) {
+      _currentState = state;
+      _currentPosition = position;
+      return true;
+  }
+
+  return false;
+}
+
+void HAValve::buildSerializer()
+{
+    if (_serializer || !uniqueId()) {
+        return;
+    }
+    
+    _serializer = new HASerializer(this, 16); //  max properties nb
+    _serializer->set(AHATOFSTR(HANameProperty), _name);
+    _serializer->set(AHATOFSTR(HAObjectIdProperty), _objectId);
+    _serializer->set(HASerializer::WithUniqueId);
+    _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);
+    _serializer->set(AHATOFSTR(HAIconProperty), _icon);
+    
+    _serializer->set(
+      AHATOFSTR(HAPositionOpenProperty),
+      &_positionOpen,
+      HASerializer::NumberPropertyType
+    );
+    
+    _serializer->set(
+      AHATOFSTR(HAPositionClosedProperty),
+      &_positionClosed,
+      HASerializer::NumberPropertyType
+    );
+    
+    if (_features & PositionFeature) {
+      _serializer->set(
+        AHATOFSTR(HAReportsPosition),
+        AHATOFSTR(HATrue),
+        HASerializer::ProgmemPropertyValue
+      );
+    }
+    
+    if (_features & StopFeature) {
+      _serializer->set(
+        AHATOFSTR(HAPayloadStopProperty),
+        AHATOFSTR(HAStopCommand),
+        HASerializer::ProgmemPropertyValue
+      );
+    }
+
+    if (_retain) {
+        _serializer->set(
+            AHATOFSTR(HARetainProperty),
+            &_retain,
+            HASerializer::BoolPropertyType
+        );
+    }
+
+    if (_optimistic) {
+        _serializer->set(
+            AHATOFSTR(HAOptimisticProperty),
+            &_optimistic,
+            HASerializer::BoolPropertyType
+        );
+    }
+
+    _serializer->set(HASerializer::WithDevice);
+    _serializer->set(HASerializer::WithAvailability);
+    _serializer->topic(AHATOFSTR(HAStateTopic));
+    _serializer->topic(AHATOFSTR(HACommandTopic));
+}
+
+void HAValve::onMqttConnected()
+{
+    if (!uniqueId()) {
+        return;
+    }
+
+    publishConfig();
+    publishAvailability();
+
+    if (!_retain) {
+      if (_features & PositionFeature) {
+        publishState(StatePublishJson, _currentState, _currentPosition);
+      } else {
+        publishState(StatePublishString, _currentState, -1);
+      }
+      publishState(StatePublishNumeric, StateUnknown, _currentPosition);
+    }
+
+    subscribeTopic(uniqueId(), AHATOFSTR(HACommandTopic));
+}
+
+void HAValve::onMqttMessage(
+    const char* topic,
+    const uint8_t* payload,
+    const uint16_t length
+)
+{
+    if (HASerializer::compareDataTopics(
+        topic,
+        uniqueId(),
+        AHATOFSTR(HACommandTopic)
+    )) {
+        handleCommand(payload, length);
+    }
+}
+
+
+bool HAValve::publishState(StatePublishType type, ValveState state, int16_t position)
+{
+  const __FlashStringHelper *stateStr = nullptr;
+  char positionStr[6 + 1] = {0}; // int16_t digits with null terminator
+  HANumeric positionNum = HANumeric(position, 0);
+  
+  // for state only or combo
+  if (type == StatePublishString  ||  type == StatePublishJson) {
+    // ensure we have a valid state
+    if (state == StateUnknown) {
+      return false;
+    } else {
+      switch (state) {
+      case StateClosed:
+          stateStr = AHATOFSTR(HAClosedState);
+          break;
+
+      case StateClosing:
+          stateStr = AHATOFSTR(HAClosingState);
+          break;
+
+      case StateOpen:
+          stateStr = AHATOFSTR(HAOpenState);
+          break;
+
+      case StateOpening:
+          stateStr = AHATOFSTR(HAOpeningState);
+          break;
+
+      default:
+          return false;
+      }
+    }
+  }
+  
+  // for position only or combo
+  if (type == StatePublishNumeric  ||  type == StatePublishJson) {
+    // ensure we have a valid position
+    if (position == DefaultPosition || !(_features & PositionFeature)) {
+      return false;
+    } else {
+      HANumeric(position, 0).toStr(positionStr);
+    }
+  }
+
+  // publish
+  if (type == StatePublishString) {
+    return publishOnDataTopic(AHATOFSTR(HAStateTopic), stateStr, true);
+  }
+  
+  if (type == StatePublishNumeric) {
+    return publishOnDataTopic(AHATOFSTR(HAStateTopic), positionStr, true);
+  }
+  
+  if (type == StatePublishJson) {
+    char jsonState[40];
+    sprintf(
+      jsonState,
+      "{\"%s\":\"%s\",\"%s\":%d}",
+      AHAFROMFSTR(HAStateProperty),
+      AHAFROMFSTR(stateStr),
+      AHAFROMFSTR(HAPositionProperty),
+      position
+    );
+    return publishOnDataTopic(AHATOFSTR(HAStateTopic), jsonState, true);
+  }
+    
+  return false;
+}
+
+
+void HAValve::handleCommand(const uint8_t* cmd, const uint16_t length)
+{
+    if (!_commandCallback) {
+        return;
+    }
+
+    if (memcmp_P(cmd, HACloseCommand, length) == 0) {
+        _commandCallback(CommandClose, this);
+    } else if (memcmp_P(cmd, HAOpenCommand, length) == 0) {
+        _commandCallback(CommandOpen, this);
+    } else if (memcmp_P(cmd, HAStopCommand, length) == 0) {
+        _commandCallback(CommandStop, this);
+    } else if (_features & PositionFeature) {
+      HANumeric number = HANumeric::fromStr(cmd, length);
+      if (number.isSet()) {
+        _commandCallback(number.toUInt16(), this);
+      }
+    }
+}
+
+#endif

--- a/src/device-types/HAValve.cpp
+++ b/src/device-types/HAValve.cpp
@@ -85,17 +85,21 @@ void HAValve::buildSerializer()
     _serializer->set(AHATOFSTR(HADeviceClassProperty), _class);
     _serializer->set(AHATOFSTR(HAIconProperty), _icon);
     
-    _serializer->set(
-      AHATOFSTR(HAPositionOpenProperty),
-      &_positionOpen,
-      HASerializer::NumberPropertyType
-    );
+    if (_positionOpen.toInt16() != 100) {
+      _serializer->set(
+        AHATOFSTR(HAPositionOpenProperty),
+        &_positionOpen,
+        HASerializer::NumberPropertyType
+      );
+    }
     
-    _serializer->set(
-      AHATOFSTR(HAPositionClosedProperty),
-      &_positionClosed,
-      HASerializer::NumberPropertyType
-    );
+    if (_positionClosed.toInt16() != 0) {
+      _serializer->set(
+        AHATOFSTR(HAPositionClosedProperty),
+        &_positionClosed,
+        HASerializer::NumberPropertyType
+      );
+    }
     
     if (_features & PositionFeature) {
       _serializer->set(
@@ -258,7 +262,7 @@ void HAValve::handleCommand(const uint8_t* cmd, const uint16_t length)
     } else if (_features & PositionFeature) {
       HANumeric number = HANumeric::fromStr(cmd, length);
       if (number.isSet()) {
-        _commandCallback(number.toUInt16(), this);
+        _commandCallback(number.toInt16(), this);
       }
     }
 }

--- a/src/device-types/HAValve.h
+++ b/src/device-types/HAValve.h
@@ -122,20 +122,24 @@ public:
         { return _currentPosition; }
 
     /**
-     * Sets the value of the open position.
+     * Set/get the value of the open position.
      *
      * @param value The setp value. By default it's `100`.
      */
     inline void setPositionOpen(const uint16_t value)
         { _positionOpen = HANumeric(value, 0); }
+    inline int16_t getPositionOpen()
+        { return _positionOpen.toInt16(); }
 
     /**
-     * Sets the value of the closed position.
+     * Set/get the value of the closed position.
      *
      * @param value The setp value. By default it's `0`.
      */
     inline void setPositionClosed(const uint16_t value)
         { _positionClosed = HANumeric(value, 0); }
+    inline int16_t getPositionClosed()
+        { return _positionClosed.toInt16(); }
 
     /**
      * Sets class of the device.

--- a/src/device-types/HAValve.h
+++ b/src/device-types/HAValve.h
@@ -1,0 +1,247 @@
+#ifndef AHA_HAVALVE_H
+#define AHA_HAVALVE_H
+
+#include "HABaseDeviceType.h"
+#include "../utils/HANumeric.h"
+#include "../utils/HASerializer.h"
+
+#ifndef EX_ARDUINOHA_VALVE
+
+#define HAVALVE_CALLBACK(name) void (*name)(int16_t cmd, HAValve* sender)
+
+/**
+ * HAValve allows to control a valve (such as water or gas).
+ *
+ * @note
+ * You can find more information about this entity in the Home Assistant documentation:
+ * https://www.home-assistant.io/integrations/valve.mqtt/
+ */
+class HAValve : public HABaseDeviceType
+{
+public:
+    static const int16_t DefaultPosition = -32768;
+
+    enum ValveState {
+        StateUnknown = 0,
+        StateClosed,
+        StateClosing,
+        StateOpen,
+        StateOpening
+    };
+
+    enum ValveCommand {
+        CommandOpen,
+        CommandClose,
+        CommandStop
+    };
+
+    enum Features {
+        DefaultFeatures = 0,
+        PositionFeature = 1,
+        StopFeature = 2
+    };
+    
+    enum StatePublishType {
+        StatePublishString,
+        StatePublishNumeric,
+        StatePublishJson
+    };
+
+    /**
+     * @param uniqueId The unique ID of the valve. It needs to be unique in a scope of your device.
+     * @param features Features that should be enabled for the fan.
+     */
+    HAValve(const char* uniqueId, const uint16_t features = DefaultFeatures);
+
+    /**
+     * Changes state of the valve and publishes MQTT message.
+     * Please note that if a new value is the same as previous one,
+     * the MQTT message won't be published.
+     *
+     * @param state New state of the valve.
+     * @param force Forces to update state without comparing it to previous known state.
+     * @returns Returns true if MQTT message has been published successfully.
+     */
+    bool setState(const ValveState state, const bool force = false);
+
+    /**
+     * Changes the position of the valve and publishes MQTT message.
+     * Please note that if a new value is the same as previous one,
+     * the MQTT message won't be published.
+     *
+     * @param position The new position of the valve (0-100).
+     * @param force Forces to update the state without comparing it to a previous known state.
+     * @returns Returns `true` if MQTT message has been published successfully.
+     */
+    bool setPosition(const int16_t position, const bool force = false);
+
+    /**
+     * Changes both the state and position of the valve and publishes MQTT message.
+     * Please note that if a both values are the same as previous ones,
+     * the MQTT message won't be published.
+     *
+     * @param state New state of the valve.
+     * @param position The new position of the valve (0-100).
+     * @param force Forces to update the state without comparing it to a previous known state.
+     * @returns Returns `true` if MQTT message has been published successfully.
+     */
+    bool setStateWithPosition(const ValveState state, const int16_t position, const bool force = false);
+
+    /**
+     * Sets the current state of the valve without publishing it to Home Assistant.
+     * This method may be useful if you want to change the state before the connection
+     * with the MQTT broker is acquired.
+     *
+     * @param state The new state of the valve.
+     */
+    inline void setCurrentState(const ValveState state)
+        { _currentState = state; }
+
+    /**
+     * Returns last known state of the valve.
+     * By default the state is set to ValveState::StateUnknown
+     */
+    inline ValveState getCurrentState() const
+        { return _currentState; }
+
+    /**
+     * Sets the current position of the valve without pushing the value to Home Assistant.
+     * This method may be useful if you want to change the position before the connection
+     * with the MQTT broker is acquired.
+     *
+     * @param position The new position of the valve (0-100).
+     */
+    inline void setCurrentPosition(const int16_t position)
+        { _currentPosition = position; }
+
+    /**
+     * Returns the last known position of the valve.
+     * By default position is set to HAValve::DefaultPosition
+     */
+    inline int16_t getCurrentPosition() const
+        { return _currentPosition; }
+
+    /**
+     * Sets the value of the open position.
+     *
+     * @param value The setp value. By default it's `100`.
+     */
+    inline void setPositionOpen(const uint16_t value)
+        { _positionOpen = HANumeric(value, 0); }
+
+    /**
+     * Sets the value of the closed position.
+     *
+     * @param value The setp value. By default it's `0`.
+     */
+    inline void setPositionClosed(const uint16_t value)
+        { _positionClosed = HANumeric(value, 0); }
+
+    /**
+     * Sets class of the device.
+     * You can find list of available values here: https://www.home-assistant.io/integrations/valve/
+     *
+     * @param deviceClass The class name.
+     */
+    inline void setDeviceClass(const char* deviceClass)
+        { _class = deviceClass; }
+
+    /**
+     * Sets icon of the valve.
+     * Any icon from MaterialDesignIcons.com (for example: `mdi:home`).
+     *
+     * @param icon The icon name.
+     */
+    inline void setIcon(const char* icon)
+        { _icon = icon; }
+
+    /**
+     * Sets retain flag for the valve's command.
+     * If set to `true` the command produced by Home Assistant will be retained.
+     *
+     * @param retain
+     */
+    inline void setRetain(const bool retain)
+        { _retain = retain; }
+
+    /**
+     * Sets optimistic flag for the valve state.
+     * In this mode the valve state doesn't need to be reported back to the HA panel when a command is received.
+     * By default the optimistic mode is disabled.
+     *
+     * @param optimistic The optimistic mode (`true` - enabled, `false` - disabled).
+     */
+    inline void setOptimistic(const bool optimistic)
+        { _optimistic = optimistic; }
+
+    /**
+     * Registers callback that will be called each time the command from HA is received.
+     * Please note that it's not possible to register multiple callbacks for the same valve.
+     *
+     * @param callback
+     */
+    inline void onCommand(HAVALVE_CALLBACK(callback))
+        { _commandCallback = callback; }
+
+protected:
+    virtual void buildSerializer() override;
+    virtual void onMqttConnected() override;
+    virtual void onMqttMessage(
+        const char* topic,
+        const uint8_t* payload,
+        const uint16_t length
+    ) override;
+
+private:    
+    /**
+     * Publishes the MQTT message with the given state as a string.
+     * For valves that do not use the "reports_position" feature, will report
+     * either numeric for position or JSON for both
+     *
+     * @param type The publish type
+     * @param state The state to publish.
+     * @param position The position to publish.
+    */
+    bool publishState(const StatePublishType type, const ValveState state, const int16_t position);
+
+    /**
+     * Parses the given command and executes the valve's callback with proper enum's property.
+     *
+     * @param cmd The data of the command.
+     * @param length Length of the command.
+     */
+    void handleCommand(const uint8_t* cmd, const uint16_t length);
+
+    /// Features enabled for the valve.
+    const uint8_t _features;
+
+    /// The current state of the valve. By default it's `HAValve::StateUnknown`.
+    ValveState _currentState;
+    
+    /// The current position of the valve. By default it's `HAValve::DefaultPosition`.
+    int16_t _currentPosition;
+
+    /// The defined close position. Defaults to 0
+    HANumeric _positionOpen;
+    
+    /// The defined close position. Defaults to 100
+    HANumeric _positionClosed;
+    
+    /// The device class. It can be nullptr.
+    const char* _class;
+
+    /// The icon of the button. It can be nullptr.
+    const char* _icon;
+
+    /// The retain flag for the HA commands.
+    bool _retain;
+
+    /// The optimistic mode of the valve (`true` - enabled, `false` - disabled).
+    bool _optimistic;
+    
+    /// The command callback that will be called when clicking the valve's button in the HA panel.
+    HAVALVE_CALLBACK(_commandCallback);
+};
+
+#endif
+#endif

--- a/src/utils/HADictionary.cpp
+++ b/src/utils/HADictionary.cpp
@@ -18,6 +18,7 @@ const char HAComponentScene[] PROGMEM = {"scene"};
 const char HAComponentFan[] PROGMEM = {"fan"};
 const char HAComponentLight[] PROGMEM = {"light"};
 const char HAComponentClimate[] PROGMEM = {"climate"};
+const char HAComponentValve[] PROGMEM = {"valve"};
 
 // decorators
 const char HASerializerSlash[] PROGMEM = {"/"};
@@ -75,6 +76,13 @@ const char HAModesProperty[] PROGMEM = {"modes"};
 const char HATemperatureCommandTemplateProperty[] PROGMEM = {"temp_cmd_tpl"};
 const char HAPayloadOnProperty[] PROGMEM = {"pl_on"};
 const char HAExpireAfterProperty[] PROGMEM = {"exp_aft"};
+const char HAPayloadOpenProperty[] PROGMEM = {"pl_open"};
+const char HAPayloadCloseProperty[] PROGMEM = {"pl_cls"};
+const char HAPayloadStopProperty[] PROGMEM = {"pl_stop"};
+const char HAStateProperty[] PROGMEM = {"state"};
+const char HAPositionProperty[] PROGMEM = {"position"};
+const char HAPositionOpenProperty[] PROGMEM = {"pos_open"};
+const char HAPositionClosedProperty[] PROGMEM = {"pos_clsd"};
 
 // topics
 const char HAConfigTopic[] PROGMEM = {"config"};
@@ -128,6 +136,7 @@ const char HAClosingState[] PROGMEM = {"closing"};
 const char HAOpenState[] PROGMEM = {"open"};
 const char HAOpeningState[] PROGMEM = {"opening"};
 const char HAStoppedState[] PROGMEM = {"stopped"};
+const char HAReportsPosition[] PROGMEM = {"pos"};
 
 // commands
 const char HAOpenCommand[] PROGMEM = {"OPEN"};

--- a/src/utils/HADictionary.h
+++ b/src/utils/HADictionary.h
@@ -18,6 +18,7 @@ extern const char HAComponentScene[];
 extern const char HAComponentFan[];
 extern const char HAComponentLight[];
 extern const char HAComponentClimate[];
+extern const char HAComponentValve[];
 
 // decorators
 extern const char HASerializerSlash[];
@@ -75,6 +76,13 @@ extern const char HAModesProperty[];
 extern const char HATemperatureCommandTemplateProperty[];
 extern const char HAPayloadOnProperty[];
 extern const char HAExpireAfterProperty[];
+extern const char HAPayloadOpenProperty[];
+extern const char HAPayloadCloseProperty[];
+extern const char HAPayloadStopProperty[];
+extern const char HAStateProperty[];
+extern const char HAPositionProperty[];
+extern const char HAPositionOpenProperty[];
+extern const char HAPositionClosedProperty[];
 
 // topics
 extern const char HAConfigTopic[];
@@ -128,6 +136,7 @@ extern const char HAClosingState[];
 extern const char HAOpenState[];
 extern const char HAOpeningState[];
 extern const char HAStoppedState[];
+extern const char HAReportsPosition[];
 
 // commands
 extern const char HAOpenCommand[];

--- a/tests/ValveTest/Makefile
+++ b/tests/ValveTest/Makefile
@@ -1,0 +1,5 @@
+APP_NAME := ValveTest
+ARDUINO_LIBS := AUnit arduino-home-assistant
+EXTRA_CPPFLAGS := "-D ARDUINOHA_TEST"
+EXTRA_CXXFLAGS := -g
+include ../../../EpoxyDuino/EpoxyDuino.mk

--- a/tests/ValveTest/ValveTest.ino
+++ b/tests/ValveTest/ValveTest.ino
@@ -1,0 +1,471 @@
+#include <AUnit.h>
+#include <ArduinoHA.h>
+
+#define prepareTest \
+    initMqttTest(testDeviceId) \
+    lastCommandCallbackCall.reset();
+
+#define assertCommandCallbackCalled(expectedCommand, callerPtr) \
+    assertTrue(lastCommandCallbackCall.called); \
+    assertEqual(expectedCommand, lastCommandCallbackCall.command); \
+    assertEqual(callerPtr, lastCommandCallbackCall.caller);
+
+#define assertCommandCallbackNotCalled() \
+    assertFalse(lastCommandCallbackCall.called);
+
+using aunit::TestRunner;
+
+struct CommandCallback {
+    bool called = false;
+    int16_t command = 0;
+    HAValve* caller = nullptr;
+
+    void reset() {
+        called = false;
+        command = 0;
+        caller = nullptr;
+    }
+};
+
+static const char* testDeviceId = "testDevice";
+static const char* testUniqueId = "uniqueValve";
+static CommandCallback lastCommandCallbackCall;
+
+const char ConfigTopic[] PROGMEM = {"homeassistant/valve/testDevice/uniqueValve/config"};
+const char StateTopic[] PROGMEM = {"testData/testDevice/uniqueValve/stat_t"};
+const char PositionTopic[] PROGMEM = {"testData/testDevice/uniqueValve/pos_t"};
+const char CommandTopic[] PROGMEM = {"testData/testDevice/uniqueValve/cmd_t"};
+
+void onCommandReceived(int16_t command, HAValve* caller)
+{
+    lastCommandCallbackCall.called = true;
+    lastCommandCallbackCall.command = command;
+    lastCommandCallbackCall.caller = caller;
+}
+
+AHA_TEST(ValveTest, invalid_unique_id) {
+    prepareTest
+
+    HAValve valve(nullptr);
+    valve.buildSerializerTest();
+    HASerializer* serializer = valve.getSerializer();
+
+    assertTrue(serializer == nullptr);
+}
+
+AHA_TEST(ValveTest, default_params) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    assertEntityConfig(
+        mock,
+        valve,
+        (
+            "{"
+            "\"uniq_id\":\"uniqueValve\","
+            "\"dev\":{\"ids\":\"testDevice\"},"
+            "\"stat_t\":\"testData/testDevice/uniqueValve/stat_t\","
+            "\"cmd_t\":\"testData/testDevice/uniqueValve/cmd_t\""
+            "}"
+        )
+    )
+    assertEqual(1, mock->getFlushedMessagesNb()); // only config should be pushed
+}
+
+AHA_TEST(ValveTest, extended_unique_id) {
+    prepareTest
+
+    device.enableExtendedUniqueIds();
+    HAValve valve(testUniqueId);
+    assertEntityConfig(
+        mock,
+        valve,
+        (
+            "{"
+            "\"uniq_id\":\"testDevice_uniqueValve\","
+            "\"dev\":{\"ids\":\"testDevice\"},"
+            "\"stat_t\":\"testData/testDevice/uniqueValve/stat_t\","
+            "\"cmd_t\":\"testData/testDevice/uniqueValve/cmd_t\""
+            "}"
+        )
+    )
+    assertEqual(1, mock->getFlushedMessagesNb()); // only config should be pushed
+}
+
+AHA_TEST(ValveTest, default_params_with_position) {
+    prepareTest
+
+    HAValve valve(testUniqueId, HAValve::PositionFeature);
+    assertEntityConfig(
+        mock,
+        valve,
+        (
+            "{"
+            "\"uniq_id\":\"uniqueValve\","
+            "\"dev\":{\"ids\":\"testDevice\"},"
+            "\"stat_t\":\"testData/testDevice/uniqueValve/stat_t\","
+            "\"cmd_t\":\"testData/testDevice/uniqueValve/cmd_t\","
+            "\"pos_t\":\"testData/testDevice/uniqueValve/pos_t\""
+            "}"
+        )
+    )
+    assertEqual(1, mock->getFlushedMessagesNb()); // only config should be pushed
+}
+
+AHA_TEST(ValveTest, command_subscription) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    mqtt.loop();
+
+    assertEqual(1, mock->getSubscriptionsNb());
+    assertEqual(AHATOFSTR(CommandTopic), mock->getSubscriptions()[0]->topic);
+}
+
+AHA_TEST(ValveTest, availability) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.setAvailability(true);
+    mqtt.loop();
+
+    // availability is published after config in HAValve
+    assertMqttMessage(
+        1,
+        F("testData/testDevice/uniqueValve/avty_t"),
+        "online",
+        true
+    )
+}
+
+AHA_TEST(ValveTest, publish_last_known_state) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.setCurrentState(HAValve::StateClosed);
+    valve.setCurrentPosition(100);
+    mqtt.loop();
+
+    assertEqual(2, mock->getFlushedMessagesNb());
+    assertMqttMessage(1, AHATOFSTR(StateTopic), "closed", true)
+}
+
+AHA_TEST(ValveTest, publish_last_known_state_with_position) {
+    prepareTest
+
+    HAValve valve(testUniqueId, HAValve::PositionFeature);
+    valve.setCurrentState(HAValve::StateClosed);
+    valve.setCurrentPosition(100);
+    mqtt.loop();
+
+    assertEqual(3, mock->getFlushedMessagesNb());
+    assertMqttMessage(1, AHATOFSTR(StateTopic), "closed", true)
+    assertMqttMessage(2, AHATOFSTR(PositionTopic), "100", true)
+}
+
+AHA_TEST(ValveTest, publish_nothing_if_retained) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.setRetain(true);
+    valve.setCurrentState(HAValve::StateClosed);
+    valve.setCurrentPosition(100);
+    mqtt.loop();
+
+    assertEqual(1, mock->getFlushedMessagesNb()); // only config should be pushed
+}
+
+AHA_TEST(ValveTest, name_setter) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.setName("testName");
+
+    assertEntityConfig(
+        mock,
+        valve,
+        (
+            "{"
+            "\"name\":\"testName\","
+            "\"uniq_id\":\"uniqueValve\","
+            "\"dev\":{\"ids\":\"testDevice\"},"
+            "\"stat_t\":\"testData/testDevice/uniqueValve/stat_t\","
+            "\"cmd_t\":\"testData/testDevice/uniqueValve/cmd_t\""
+            "}"
+        )
+    )
+}
+
+AHA_TEST(ValveTest, object_id_setter) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.setObjectId("testId");
+
+    assertEntityConfig(
+        mock,
+        valve,
+        (
+            "{"
+            "\"obj_id\":\"testId\","
+            "\"uniq_id\":\"uniqueValve\","
+            "\"dev\":{\"ids\":\"testDevice\"},"
+            "\"stat_t\":\"testData/testDevice/uniqueValve/stat_t\","
+            "\"cmd_t\":\"testData/testDevice/uniqueValve/cmd_t\""
+            "}"
+        )
+    )
+}
+
+AHA_TEST(ValveTest, device_class) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.setDeviceClass("testClass");
+
+    assertEntityConfig(
+        mock,
+        valve,
+        (
+            "{"
+            "\"uniq_id\":\"uniqueValve\","
+            "\"dev_cla\":\"testClass\","
+            "\"dev\":{\"ids\":\"testDevice\"},"
+            "\"stat_t\":\"testData/testDevice/uniqueValve/stat_t\","
+            "\"cmd_t\":\"testData/testDevice/uniqueValve/cmd_t\""
+            "}"
+        )
+    )
+}
+
+AHA_TEST(ValveTest, icon_setter) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.setIcon("testIcon");
+
+    assertEntityConfig(
+        mock,
+        valve,
+        (
+            "{"
+            "\"uniq_id\":\"uniqueValve\","
+            "\"ic\":\"testIcon\","
+            "\"dev\":{\"ids\":\"testDevice\"},"
+            "\"stat_t\":\"testData/testDevice/uniqueValve/stat_t\","
+            "\"cmd_t\":\"testData/testDevice/uniqueValve/cmd_t\""
+            "}"
+        )
+    )
+}
+
+AHA_TEST(ValveTest, retain_setter) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.setRetain(true);
+
+    assertEntityConfig(
+        mock,
+        valve,
+        (
+            "{"
+            "\"uniq_id\":\"uniqueValve\","
+            "\"ret\":true,"
+            "\"dev\":{\"ids\":\"testDevice\"},"
+            "\"stat_t\":\"testData/testDevice/uniqueValve/stat_t\","
+            "\"cmd_t\":\"testData/testDevice/uniqueValve/cmd_t\""
+            "}"
+        )
+    )
+}
+
+AHA_TEST(ValveTest, optimistic_setter) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.setOptimistic(true);
+
+    assertEntityConfig(
+        mock,
+        valve,
+        (
+            "{"
+            "\"uniq_id\":\"uniqueValve\","
+            "\"opt\":true,"
+            "\"dev\":{\"ids\":\"testDevice\"},"
+            "\"stat_t\":\"testData/testDevice/uniqueValve/stat_t\","
+            "\"cmd_t\":\"testData/testDevice/uniqueValve/cmd_t\""
+            "}"
+        )
+    )
+}
+
+AHA_TEST(ValveTest, current_state_setter) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.setCurrentState(HAValve::StateClosed);
+
+    assertEqual(0, mock->getFlushedMessagesNb());
+    assertEqual(HAValve::StateClosed, valve.getCurrentState());
+}
+
+AHA_TEST(ValveTest, current_position_setter) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.setCurrentPosition(500);
+
+    assertEqual(0, mock->getFlushedMessagesNb());
+    assertEqual(500, valve.getCurrentPosition());
+}
+
+AHA_TEST(ValveTest, publish_state_closed) {
+    prepareTest
+
+    mock->connectDummy();
+    HAValve valve(testUniqueId);
+
+    assertTrue(valve.setState(HAValve::StateClosed));
+    assertSingleMqttMessage(AHATOFSTR(StateTopic), "closed", true)
+}
+
+AHA_TEST(ValveTest, publish_state_closing) {
+    prepareTest
+
+    mock->connectDummy();
+    HAValve valve(testUniqueId);
+
+    assertTrue(valve.setState(HAValve::StateClosing));
+    assertSingleMqttMessage(AHATOFSTR(StateTopic), "closing", true)
+}
+
+AHA_TEST(ValveTest, publish_state_open) {
+    prepareTest
+
+    mock->connectDummy();
+    HAValve valve(testUniqueId);
+
+    assertTrue(valve.setState(HAValve::StateOpen));
+    assertSingleMqttMessage(AHATOFSTR(StateTopic), "open", true)
+}
+
+AHA_TEST(ValveTest, publish_state_opening) {
+    prepareTest
+
+    mock->connectDummy();
+    HAValve valve(testUniqueId);
+
+    assertTrue(valve.setState(HAValve::StateOpening));
+    assertSingleMqttMessage(AHATOFSTR(StateTopic), "opening", true)
+}
+
+AHA_TEST(ValveTest, publish_position) {
+    prepareTest
+
+    mock->connectDummy();
+    HAValve valve(testUniqueId, HAValve::PositionFeature);
+
+    assertTrue(valve.setPosition(250));
+    assertSingleMqttMessage(AHATOFSTR(PositionTopic), "250", true)
+}
+
+AHA_TEST(ValveTest, publish_position_max) {
+    prepareTest
+
+    mock->connectDummy();
+    HAValve valve(testUniqueId, HAValve::PositionFeature);
+
+    assertTrue(valve.setPosition(32767));
+    assertSingleMqttMessage(AHATOFSTR(PositionTopic), "32767", true)
+}
+
+AHA_TEST(ValveTest, publish_position_debounce) {
+    prepareTest
+
+    mock->connectDummy();
+    HAValve valve(testUniqueId, HAValve::PositionFeature);
+    valve.setCurrentPosition(250);
+
+    // it shouldn't publish data if state doesn't change
+    assertTrue(valve.setPosition(250));
+    assertEqual(mock->getFlushedMessagesNb(), 0);
+}
+
+AHA_TEST(ValveTest, publish_position_debounce_skip) {
+    prepareTest
+
+    mock->connectDummy();
+    HAValve valve(testUniqueId, HAValve::PositionFeature);
+    valve.setCurrentPosition(250);
+
+    assertTrue(valve.setPosition(250, true));
+    assertSingleMqttMessage(AHATOFSTR(PositionTopic), "250", true)
+}
+
+AHA_TEST(ValveTest, command_open) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.onCommand(onCommandReceived);
+    mock->fakeMessage(AHATOFSTR(CommandTopic), F("OPEN"));
+
+    assertCommandCallbackCalled(HAValve::CommandOpen, &valve)
+}
+
+AHA_TEST(ValveTest, command_close) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.onCommand(onCommandReceived);
+    mock->fakeMessage(AHATOFSTR(CommandTopic), F("CLOSE"));
+
+    assertCommandCallbackCalled(HAValve::CommandClose, &valve)
+}
+
+AHA_TEST(ValveTest, command_stop) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.onCommand(onCommandReceived);
+    mock->fakeMessage(AHATOFSTR(CommandTopic), F("STOP"));
+
+    assertCommandCallbackCalled(HAValve::CommandStop, &valve)
+}
+
+AHA_TEST(ValveTest, command_invalid) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.onCommand(onCommandReceived);
+    mock->fakeMessage(AHATOFSTR(CommandTopic), F("NOT_SUPPORTED"));
+
+    assertCommandCallbackNotCalled()
+}
+
+AHA_TEST(ValveTest, different_valve_command) {
+    prepareTest
+
+    HAValve valve(testUniqueId);
+    valve.onCommand(onCommandReceived);
+    mock->fakeMessage(
+        F("testData/testDevice/uniqueValveDifferent/cmd_t"),
+        F("CLOSE")
+    );
+
+    assertCommandCallbackNotCalled()
+}
+
+void setup()
+{
+    delay(1000);
+    Serial.begin(115200);
+    while (!Serial);
+}
+
+void loop()
+{
+    TestRunner::run();
+    delay(1);
+}


### PR DESCRIPTION
For issue https://github.com/dawidchyrzynski/arduino-home-assistant/issues/239

Not sure if this project is active anymore. Looks like no releases in over a year now?

1) I am not sure the what best implementation of this device is. Valve would make a lot more sense to me as a sub-class of Cover, as it shares most of the commands/states/features. But HA isn't about consistency, so here we are. Instead of having a dedicated position topic (like Cover), the Valve sends two different types of commands. Commands are strings for standard valves, but numeric for positional valves. Also, publishing is strings for standard, but either numeric or JSON for positions. I have tried to cover all of these use cases. There is also a STOP command (but *no* STOP state)... but it has to be explicitly enabled, and I have no idea under what conditions HA would actually send it.

2) I am running a live device on the standard valve implementation, and a test device for the positional setup. Both are ESP8266. I have added a few test cases to support the different position cases.

3) Finally, also not sure how to handle the generated documentation. There seems to be a mismatch between the current pip requirements (sphinx=5.0.2) and the actual docs committed to the repo (sphinx=4.5.0). So if I run the generate command, it updates 95% of the doc files. This PR is done without any doc changes, or I can use a branch that has all the changes.