### PR TITLE
feat: Add uppercase option for unique IDs from byte arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+**New features:**
+* Added an option to generate uppercase unique IDs from byte arrays.
+
 ## 2.1.0
 
 **New features:**

--- a/src/HADevice.cpp
+++ b/src/HADevice.cpp
@@ -49,11 +49,18 @@ HADevice::~HADevice()
 
 bool HADevice::setUniqueId(const byte* uniqueId, const uint16_t length)
 {
+    // For backward compatibility, default to lowercase.
+    return setUniqueId(uniqueId, length, false);
+}
+
+bool HADevice::setUniqueId(const byte* uniqueId, const uint16_t length, bool uppercase)
+{
     if (_uniqueId) {
         return false; // unique ID cannot be changed at runtime once it's set
     }
 
-    _uniqueId = HAUtils::byteArrayToStr(uniqueId, length);
+    // Call the new HAUtils function with the uppercase flag.
+    _uniqueId = HAUtils::byteArrayToStr(uniqueId, length, uppercase);
     _ownsUniqueId = true;
     _serializer->set(AHATOFSTR(HADeviceIdentifiersProperty), _uniqueId);
     return true;

--- a/src/HADevice.h
+++ b/src/HADevice.h
@@ -88,13 +88,24 @@ public:
 
     /**
      * Sets unique ID of the device based on the given byte array.
-     * Each byte is converted into a hex string representation, so the final length of the unique ID will be twice as given.
+     * Each byte is converted into a hex string representation (lowercase by default), so the final length of the unique ID will be twice as given.
      *
      * @param uniqueId Bytes array that's going to be converted into the string.
      * @param length Number of bytes in the array.
      * @note The unique ID can be set only once (via constructor or using this method).
      */
     bool setUniqueId(const byte* uniqueId, const uint16_t length);
+	
+	/**
+     * Sets unique ID of the device based on the given byte array with case selection.
+	 * Each byte is converted into a hex string representation, so the final length of the unique ID will be twice as given.
+     *
+     * @param uniqueId Bytes array that's going to be converted into the string.
+     * @param length Number of bytes in the array.
+     * @param uppercase If true, the output will be uppercase; otherwise, it will be lowercase.
+     * @note The unique ID can be set only once (via constructor or using this method).
+     */
+    bool setUniqueId(const byte* uniqueId, const uint16_t length, bool uppercase);
 
     /**
      * Sets the "manufacturer" property that's going to be displayed in the Home Assistant.

--- a/src/utils/HAUtils.cpp
+++ b/src/utils/HAUtils.cpp
@@ -37,12 +37,34 @@ void HAUtils::byteArrayToStr(
 }
 
 char* HAUtils::byteArrayToStr(
-    const byte* src,
-    const uint16_t length
+	const byte* data, 
+	const uint16_t length
 )
 {
-    char* dst = new char[(length * 2) + 1]; // include null terminator
-    byteArrayToStr(dst, src, length);
+    // For backward compatibility, default to lowercase.
+    return byteArrayToStr(data, length, false);
+}
 
-    return dst;
+char* HAUtils::byteArrayToStr(
+	const byte* data, 
+	const uint16_t length, 
+	bool uppercase
+)
+{
+    const uint16_t strLength = length * 2;
+    if (strLength == 0) {
+        return nullptr;
+    }
+
+    char* str = new char[strLength + 1];
+    str[strLength] = '\0';
+
+    // Choose the format specifier based on the 'uppercase' parameter.
+    const char* format = uppercase ? "%02X" : "%02x";
+
+    for (int i = 0; i < length; i++) {
+        sprintf(&str[i * 2], format, data[i]);
+    }
+
+    return str;
 }

--- a/src/utils/HAUtils.h
+++ b/src/utils/HAUtils.h
@@ -36,17 +36,28 @@ public:
     );
 
     /**
-     * Converts the given byte array into hex string.
-     * This method allocates a new memory.
-     *
-     * @param src Bytes array to convert.
-     * @param length Length of the bytes array.
-     * @returns Newly allocated string containing the hex representation.
+     * Converts given byte array into the string of hex values.
+     * @param data Bytes to convert.
+     * @param length Number of bytes to convert.
+     * @return Dynamically allocated string with hex values. You're responsible for deleting it.
      */
     static char* byteArrayToStr(
-        const byte* src,
-        const uint16_t length
-    );
+		const byte* data, 
+		const uint16_t length
+	);
+
+    /**
+     * Converts given byte array into the string of hex values with optional uppercase formatting.
+     * @param data Bytes to convert.
+     * @param length Number of bytes to convert.
+     * @param uppercase If true, the output will be uppercase; otherwise, it will be lowercase.
+     * @return Dynamically allocated string with hex values. You're responsible for deleting it.
+     */
+    static char* byteArrayToStr(
+		const byte* data, 
+		const uint16_t length, 
+		bool uppercase
+	);
 };
 
 #endif


### PR DESCRIPTION
### Summary

This pull request introduces the ability for users to generate uppercase hexadecimal unique IDs when creating a device ID from a byte array (such as a MAC address).

The motivation for this change comes from my own usage. I have several existing Arduino sensors that use this library where the unique ID was manually set as an uppercase string from the MAC address. To maintain consistency and keep years of historical data in Home Assistant, I could not switch to the more convenient `setUniqueId(byte[] mac, ...)` function because it only produces lowercase output.

This change adds a non-breaking option to generate uppercase output, providing more flexibility for both new and existing users who require a specific format.

### Changes Made

To achieve this while maintaining full backward compatibility, the following changes were implemented:

- **`HAUtils::byteArrayToStr`:** Overloaded the function to accept an optional `bool uppercase` parameter. The original function now calls this new overload with `false` to ensure existing behavior is unchanged.
- **`HADevice::setUniqueId`:** Similarly, overloaded the function to accept an optional `bool uppercase` parameter, exposing the new functionality to the end-user.
- **Changelog:** Added an entry to `CHANGELOG.md` for this new feature.

### Contributor Checklist

- [x] The code change is implemented.
- [x] An entry has been added to `CHANGELOG.md`.
- [x] I have tested this on my own hardware (Arduino UNO R4 Minima + Ethernet Shield) and it works as expected.

This enhancement is fully tested and documented. I look forward to your feedback!