### PR TITLE
Add IMqttClient abstract interface (additive overload)

### DIFF
--- a/src/ArduinoHA.h
+++ b/src/ArduinoHA.h
@@ -3,6 +3,8 @@
 
 #include "HADevice.h"
 #include "HAMqtt.h"
+#include "IMqttClient.h"
+#include "PubSubClientAdapter.h"
 #include "device-types/HABinarySensor.h"
 #include "device-types/HAButton.h"
 #include "device-types/HACamera.h"

--- a/src/HAMqtt.cpp
+++ b/src/HAMqtt.cpp
@@ -1,7 +1,8 @@
 #include "HAMqtt.h"
 
 #ifndef ARDUINOHA_TEST
-#include <PubSubClient.h>
+#include "IMqttClient.h"
+#include "PubSubClientAdapter.h"
 #endif
 
 #include "HADevice.h"
@@ -59,7 +60,18 @@ HAMqtt::HAMqtt(
     HADevice& device,
     uint8_t maxDevicesTypesNb
 ) :
-    _mqtt(new PubSubClient(netClient)),
+    _mqtt(new PubSubClientAdapter(netClient)),
+    HAMQTT_INIT
+{
+    _instance = this;
+}
+
+HAMqtt::HAMqtt(
+    IMqttClient* client,
+    HADevice& device,
+    uint8_t maxDevicesTypesNb
+) :
+    _mqtt(client),
     HAMQTT_INIT
 {
     _instance = this;

--- a/src/HAMqtt.h
+++ b/src/HAMqtt.h
@@ -14,7 +14,7 @@
 #ifdef ARDUINOHA_TEST
 class PubSubClientMock;
 #else
-class PubSubClient;
+class IMqttClient;
 #endif
 
 #if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__)
@@ -66,7 +66,7 @@ public:
     );
 #else
     /**
-     * Creates a new instance of the HAMqtt class.
+     * Creates a new instance of the HAMqtt class backed by PubSubClient.
      * Please note that only one instance of the class can be initialized at the same time.
      *
      * @param netClient The EthernetClient or WiFiClient that's going to be used for the network communication.
@@ -75,6 +75,25 @@ public:
      */
     explicit HAMqtt(
         Client& netClient,
+        HADevice& device,
+        const uint8_t maxDevicesTypesNb = HAMQTT_DEFAULT_DEVICES_LIMIT
+    );
+
+    /**
+     * Creates a new instance of the HAMqtt class backed by a custom MQTT client.
+     * Use this overload to plug in alternative transports (AsyncMqttClient,
+     * ESP-IDF native MQTT, etc.) by supplying your own IMqttClient adapter.
+     *
+     * @note HAMqtt takes ownership of the pointer and deletes it in its
+     *       destructor. Heap-allocate the adapter with `new`.
+     * @note Only one instance of HAMqtt can be initialized at the same time.
+     *
+     * @param client An IMqttClient adapter (see IMqttClient.h for the contract).
+     * @param device An instance of the HADevice class representing your device.
+     * @param maxDevicesTypesNb The maximum number of device types (sensors, switches, etc.) that you're going to implement.
+     */
+    explicit HAMqtt(
+        IMqttClient* client,
         HADevice& device,
         const uint8_t maxDevicesTypesNb = HAMQTT_DEFAULT_DEVICES_LIMIT
     );
@@ -403,8 +422,10 @@ private:
 #ifdef ARDUINOHA_TEST
     PubSubClientMock* _mqtt;
 #else
-    /// Instance of the PubSubClient class. It's initialized in the constructor.
-    PubSubClient* _mqtt;
+    /// MQTT transport — owned by HAMqtt. Initialized in the constructor,
+    /// either as a PubSubClientAdapter (Client& overload) or as the
+    /// user-supplied adapter (IMqttClient* overload).
+    IMqttClient* _mqtt;
 #endif
 
     /// Instance of the HADevice passed to the constructor.

--- a/src/IMqttClient.h
+++ b/src/IMqttClient.h
@@ -1,0 +1,118 @@
+#ifndef AHA_IMQTTCLIENT_H
+#define AHA_IMQTTCLIENT_H
+
+#include <Arduino.h>
+#include <IPAddress.h>
+
+// MQTT_CALLBACK_SIGNATURE mirrors the definition in PubSubClient.h.
+// Duplicated here (with a guard) so this header can be included without
+// forcing a PubSubClient dependency on translation units that only need
+// the abstract interface.
+#ifndef MQTT_CALLBACK_SIGNATURE
+#if defined(ESP8266) || defined(ESP32)
+#include <functional>
+#define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)> callback
+#else
+#define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, unsigned int)
+#endif
+#endif
+
+#if defined(ARDUINO_API_VERSION)
+using namespace arduino;
+#endif
+
+/**
+ * Abstract transport interface used by HAMqtt.
+ *
+ * By default HAMqtt is constructed with a `Client&` (EthernetClient,
+ * WiFiClient, etc.) and internally wraps it in PubSubClient via
+ * PubSubClientAdapter. To use a different MQTT stack — AsyncMqttClient,
+ * ESP-IDF native MQTT, a mock, etc. — implement this interface and pass
+ * an instance to the `HAMqtt(IMqttClient*, HADevice&, uint8_t)` overload.
+ *
+ * Ownership: HAMqtt takes ownership of the pointer it receives and
+ * deletes it in its destructor. Heap-allocate your adapter with `new`.
+ *
+ * State contract: the integer returned from `state()` is surfaced
+ * directly via `HAMqtt::ConnectionState`. Values MUST follow the
+ * PubSubClient convention so existing user code that switches on the
+ * enum keeps working:
+ *
+ *   -5 Connecting     0 Connected     3 Unavailable
+ *   -4 Timeout        1 BadProtocol   4 BadCredentials
+ *   -3 Lost           2 BadClientId   5 Unauthorized
+ *   -2 Failed
+ *   -1 Disconnected
+ *
+ * Adapters for non-PubSub backends are responsible for mapping native
+ * error codes onto these values.
+ *
+ * Minimal adapter skeleton:
+ * @code
+ * class MyBackendAdapter : public IMqttClient {
+ *     MyBackend _backend;
+ * public:
+ *     bool loop() override { _backend.poll(); return _backend.isConnected(); }
+ *     void disconnect() override { _backend.close(); }
+ *     bool connected() override { return _backend.isConnected(); }
+ *     int16_t state() override { return _backend.isConnected() ? 0 : -1; }
+ *     // ...the rest...
+ * };
+ *
+ * auto* adapter = new MyBackendAdapter();
+ * HAMqtt mqtt(adapter, device);
+ * @endcode
+ */
+class IMqttClient
+{
+public:
+    virtual ~IMqttClient() = default;
+
+    /// Pumps the client. Called by HAMqtt::loop(). Returns false when disconnected.
+    virtual bool loop() = 0;
+
+    /// Closes the MQTT session.
+    virtual void disconnect() = 0;
+
+    /// True while the MQTT session is established.
+    virtual bool connected() = 0;
+
+    /// Current state, encoded per the PubSubClient convention. See class docs.
+    virtual int16_t state() = 0;
+
+    /**
+     * Attempts to connect to the broker. Argument semantics match
+     * PubSubClient::connect(). Last-will parameters may be nullptr.
+     */
+    virtual bool connect(
+        const char* id,
+        const char* user,
+        const char* pass,
+        const char* willTopic,
+        uint8_t willQos,
+        bool willRetain,
+        const char* willMessage,
+        bool cleanSession
+    ) = 0;
+
+    virtual void setServer(IPAddress ip, uint16_t port) = 0;
+    virtual void setServer(const char* domain, uint16_t port) = 0;
+
+    /// Registers the incoming-message callback. Signature is platform-dependent
+    /// (std::function on ESP8266/ESP32, function pointer on AVR).
+    virtual void setCallback(MQTT_CALLBACK_SIGNATURE) = 0;
+
+    virtual void setKeepAlive(uint16_t keepAlive) = 0;
+
+    /// Returns false if the backend refused the requested buffer size.
+    virtual bool setBufferSize(uint16_t size) = 0;
+
+    virtual bool beginPublish(const char* topic, unsigned int plength, bool retained) = 0;
+    virtual size_t write(const uint8_t* buffer, size_t size) = 0;
+    virtual size_t print(const __FlashStringHelper* buffer) = 0;
+    virtual int endPublish() = 0;
+
+    virtual bool subscribe(const char* topic) = 0;
+};
+
+#endif

--- a/src/PubSubClientAdapter.cpp
+++ b/src/PubSubClientAdapter.cpp
@@ -1,0 +1,112 @@
+#include "PubSubClientAdapter.h"
+
+#ifndef ARDUINOHA_TEST
+
+#include <PubSubClient.h>
+
+PubSubClientAdapter::PubSubClientAdapter(Client& netClient) :
+    _pubSub(new PubSubClient(netClient))
+{
+}
+
+PubSubClientAdapter::PubSubClientAdapter(PubSubClient* pubSub) :
+    _pubSub(pubSub)
+{
+}
+
+PubSubClientAdapter::~PubSubClientAdapter()
+{
+    if (_pubSub) {
+        delete _pubSub;
+    }
+}
+
+bool PubSubClientAdapter::loop()
+{
+    return _pubSub->loop();
+}
+
+void PubSubClientAdapter::disconnect()
+{
+    _pubSub->disconnect();
+}
+
+bool PubSubClientAdapter::connected()
+{
+    return _pubSub->connected();
+}
+
+int16_t PubSubClientAdapter::state()
+{
+    return _pubSub->state();
+}
+
+bool PubSubClientAdapter::connect(
+    const char* id,
+    const char* user,
+    const char* pass,
+    const char* willTopic,
+    uint8_t willQos,
+    bool willRetain,
+    const char* willMessage,
+    bool cleanSession
+)
+{
+    return _pubSub->connect(
+        id, user, pass,
+        willTopic, willQos, willRetain, willMessage,
+        cleanSession
+    );
+}
+
+void PubSubClientAdapter::setServer(IPAddress ip, uint16_t port)
+{
+    _pubSub->setServer(ip, port);
+}
+
+void PubSubClientAdapter::setServer(const char* domain, uint16_t port)
+{
+    _pubSub->setServer(domain, port);
+}
+
+void PubSubClientAdapter::setCallback(MQTT_CALLBACK_SIGNATURE)
+{
+    _pubSub->setCallback(callback);
+}
+
+void PubSubClientAdapter::setKeepAlive(uint16_t keepAlive)
+{
+    _pubSub->setKeepAlive(keepAlive);
+}
+
+bool PubSubClientAdapter::setBufferSize(uint16_t size)
+{
+    return _pubSub->setBufferSize(size);
+}
+
+bool PubSubClientAdapter::beginPublish(const char* topic, unsigned int plength, bool retained)
+{
+    return _pubSub->beginPublish(topic, plength, retained);
+}
+
+size_t PubSubClientAdapter::write(const uint8_t* buffer, size_t size)
+{
+    return _pubSub->write(buffer, size);
+}
+
+size_t PubSubClientAdapter::print(const __FlashStringHelper* buffer)
+{
+    return _pubSub->print(buffer);
+}
+
+int PubSubClientAdapter::endPublish()
+{
+    return _pubSub->endPublish();
+}
+
+bool PubSubClientAdapter::subscribe(const char* topic)
+{
+    return _pubSub->subscribe(topic);
+}
+
+#endif  // !ARDUINOHA_TEST

--- a/src/PubSubClientAdapter.h
+++ b/src/PubSubClientAdapter.h
@@ -1,0 +1,70 @@
+#ifndef AHA_PUBSUBCLIENTADAPTER_H
+#define AHA_PUBSUBCLIENTADAPTER_H
+
+#ifndef ARDUINOHA_TEST
+
+#include "IMqttClient.h"
+
+class Client;
+class PubSubClient;
+
+/**
+ * IMqttClient implementation backed by PubSubClient.
+ *
+ * This is the default transport used by the `HAMqtt(Client&, ...)`
+ * constructor and preserves the exact behavior the library has shipped
+ * with since 1.x. There is usually no reason to instantiate this class
+ * directly — it exists so users who want to layer customization on top
+ * of PubSubClient (for example, pre-configuring buffer size or TLS) can
+ * construct their own PubSubClient and pass it in.
+ *
+ * Takes ownership of the wrapped PubSubClient and deletes it in the
+ * destructor.
+ */
+class PubSubClientAdapter : public IMqttClient
+{
+public:
+    /// Constructs a fresh PubSubClient bound to `netClient` and adopts it.
+    explicit PubSubClientAdapter(Client& netClient);
+
+    /// Adopts an already-constructed PubSubClient. HAMqtt/this adapter
+    /// will delete it on destruction — do not share across adapters.
+    explicit PubSubClientAdapter(PubSubClient* pubSub);
+
+    ~PubSubClientAdapter() override;
+
+    bool loop() override;
+    void disconnect() override;
+    bool connected() override;
+    int16_t state() override;
+
+    bool connect(
+        const char* id,
+        const char* user,
+        const char* pass,
+        const char* willTopic,
+        uint8_t willQos,
+        bool willRetain,
+        const char* willMessage,
+        bool cleanSession
+    ) override;
+
+    void setServer(IPAddress ip, uint16_t port) override;
+    void setServer(const char* domain, uint16_t port) override;
+    void setCallback(MQTT_CALLBACK_SIGNATURE) override;
+    void setKeepAlive(uint16_t keepAlive) override;
+    bool setBufferSize(uint16_t size) override;
+
+    bool beginPublish(const char* topic, unsigned int plength, bool retained) override;
+    size_t write(const uint8_t* buffer, size_t size) override;
+    size_t print(const __FlashStringHelper* buffer) override;
+    int endPublish() override;
+
+    bool subscribe(const char* topic) override;
+
+private:
+    PubSubClient* _pubSub;
+};
+
+#endif  // !ARDUINOHA_TEST
+#endif

--- a/src/mocks/PubSubClientMock.h
+++ b/src/mocks/PubSubClientMock.h
@@ -6,11 +6,13 @@
 #include <Arduino.h>
 #include <IPAddress.h>
 
+#ifndef MQTT_CALLBACK_SIGNATURE
 #if defined(ESP8266) || defined(ESP32)
 #include <functional>
 #define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)> callback
 #else
 #define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, unsigned int)
+#endif
 #endif
 
 struct MqttMessage


### PR DESCRIPTION
Introduces an IMqttClient abstraction over the MQTT transport so users can plug in alternative stacks (AsyncMqttClient, ESP-IDF native MQTT, etc.) without forking HAMqtt.

- New IMqttClient.h — abstract interface, 15 virtual methods matching the subset of PubSubClient's API that HAMqtt actually calls. Documents the PubSubClient-compatible state() contract that adapters must preserve.
- New PubSubClientAdapter.{h,cpp} — default implementation wrapping PubSubClient; owns the wrapped client and deletes it on destruction. Two constructors: Client& (fresh PubSubClient) and PubSubClient* (adopt an already-configured one, e.g. for TLS setup).
- HAMqtt: _mqtt is now IMqttClient* in the non-test build. Existing HAMqtt(Client&, ...) constructor is unchanged from a caller's view — it now internally instantiates PubSubClientAdapter. New overload HAMqtt(IMqttClient*, ...) accepts any adapter.
- Guard MQTT_CALLBACK_SIGNATURE in PubSubClientMock.h so it doesn't redefine when IMqttClient.h is also included.
- Re-export IMqttClient + PubSubClientAdapter via ArduinoHA.h so users of the umbrella include can reach the new types.

Test build path (ARDUINOHA_TEST): unchanged. _mqtt stays a PubSubClientMock* and the test constructor is untouched, so existing unit tests compile and behave identically.

Backwards compatibility: zero breaking changes. All existing sketches using HAMqtt(Client&, device) continue to compile, link, and run with the same semantics, same PubSubClient dependency, same ConnectionState enum values. library.properties:depends=PubSubClient left unchanged.

Costs on AVR/ESP8266: +1 virtual dispatch per transport call (network -bound path), ~100-200B flash for the vtable, 2-4B RAM for the vtable pointer in HAMqtt.